### PR TITLE
Properly handle :cq

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -22,6 +22,9 @@ use cairo;
 use gdk;
 use gdk::{EventButton, EventMotion, EventScroll, EventType, ModifierType};
 use glib;
+use gio;
+use gio::ApplicationCommandLine;
+use gio::prelude::*;
 use gtk;
 use gtk::{Button, MenuButton, Notebook};
 use gtk::prelude::*;
@@ -233,6 +236,8 @@ pub struct State {
     subscriptions: RefCell<Subscriptions>,
 
     action_widgets: Arc<UiMutex<Option<ActionWidgets>>>,
+
+    app_cmdline: Arc<Mutex<Option<ApplicationCommandLine>>>,
 }
 
 impl State {
@@ -294,6 +299,8 @@ impl State {
             subscriptions: RefCell::new(Subscriptions::new()),
 
             action_widgets: Arc::new(UiMutex::new(None)),
+
+            app_cmdline: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -433,6 +440,12 @@ impl State {
         if let Some(cursor) = &mut self.cursor {
             cursor.set_cursor_blink(val);
         }
+    }
+
+    pub fn set_exit_status(&self, val: i32) {
+        let lock = self.app_cmdline.lock().unwrap();
+        let r: &ApplicationCommandLine = lock.as_ref().unwrap();
+        r.set_exit_status(val);
     }
 
     pub fn open_file(&self, path: &str) {
@@ -901,7 +914,9 @@ impl Shell {
         state.nvim.is_initialized()
     }
 
-    pub fn init(&mut self) {
+    pub fn init(&mut self, app_cmdline: Arc<Mutex<Option<ApplicationCommandLine>>>) {
+        self.state.borrow_mut().app_cmdline = app_cmdline.clone();
+
         let state = self.state.borrow();
 
         state.drawing_area.set_hexpand(true);
@@ -1215,6 +1230,10 @@ impl Shell {
             .borrow()
             .popup_menu
             .set_preview(options.contains("preview"));
+    }
+
+    pub fn set_exit_status(&self, status: i32) {
+        self.state.borrow().set_exit_status(status);
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,12 +2,12 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::convert::TryFrom;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::{env, thread};
 
 use gdk;
 use gio::prelude::*;
-use gio::{Menu, MenuItem, SimpleAction};
+use gio::{ApplicationCommandLine, Menu, MenuItem, SimpleAction};
 use glib::variant::FromVariant;
 use gtk::{
     self,
@@ -121,7 +121,7 @@ impl Ui {
         }
     }
 
-    pub fn init(&mut self, app: &gtk::Application, restore_win_state: bool) {
+    pub fn init(&mut self, app: &gtk::Application, restore_win_state: bool, app_cmdline: Arc<Mutex<Option<ApplicationCommandLine>>>) {
         if self.initialized {
             return;
         }
@@ -144,7 +144,7 @@ impl Ui {
             // for event processing
             let mut comps = comps_ref.borrow_mut();
 
-            self.shell.borrow_mut().init();
+            self.shell.borrow_mut().init(app_cmdline);
 
             comps.window = Some(window.clone());
 
@@ -257,6 +257,12 @@ impl Ui {
             SubscriptionKey::with_pattern("OptionSet", "background"),
             &["&background"],
             clone!(shell_ref => move |args| set_background(&*shell_ref, args)),
+        );
+
+        shell.state.borrow().subscribe(
+            SubscriptionKey::from("VimLeave"),
+            &["v:exiting ? v:exiting : 0"],
+            clone!(shell_ref => move |args| set_exit_status(&*shell_ref, args)),
         );
 
         window.connect_delete_event(clone!(comps_ref, shell_ref => move |_, _| {
@@ -644,6 +650,11 @@ fn update_window_title(comps: &Arc<UiMutex<Components>>, args: Vec<String>) {
     };
 
     window.set_title(filename);
+}
+
+fn set_exit_status(shell: &RefCell<Shell>, args: Vec<String>) {
+    let status = args[0].parse().unwrap();
+    shell.borrow().set_exit_status(status);
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
When the user invokes `:cq`, this causes Neovim to exit unsuccessfully.
This is important if the user wishes to abort a Git commit message, or
in other situations where the operation is aborted when the editor exits
unsuccessfully.  However, neovim-gtk doesn't exit unsuccessfully in this case.

Let's make this work by listening to the `VimLeavePre` autocommand and
then reading the v:exiting code, which indicates the exit status with
which Neovim is exiting.  Save this into the state, and then when the
detach callback is called, exit with the appropriate status.

Note that we use a separate Arc/Mutex construction here because
otherwise we need to borrow the state mutably, and at that point it's
already borrowed and we panic.  This allows us to not need to do that,
and henceforth avoid the panic.