### PR TITLE
Silently ignore the blend attribute for highlights

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -280,6 +280,7 @@ impl Highlight {
                 "underline" => model_attrs.underline = true,
                 "undercurl" => model_attrs.undercurl = true,
                 "strikethrough" => model_attrs.strikethrough = true,
+                "blend" => (),
                 attr_key => error!("unknown attribute {}", attr_key),
             };
         }


### PR DESCRIPTION
Newer versions of Neovim, such as 0.6, support the blend attribute for
colors.  This enables pseudo-transparency for popup or floating windows.
We don't currently support this, which is fine, since the documentation
says it's UI dependent.  However, since Neovim still sends it to us, we
currently emit a message like the following every time we start up
without detaching from the terminal:

```
ERROR nvim_gtk::highlight unknown attribute blend
```

This is annoying, especially when neovim-gtk is being run from another
program, such as Git.

Since we don't support this attribute right now, let's just silently
ignore it until we do, which prevents cluttering the user's terminal,
and then we can implement it at our leisure.