### PR TITLE
Don't use predictably named temporary files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,12 +94,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,15 +602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "js-sys"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +739,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "unix-daemonize",
- "whoami",
  "winres",
 ]
 
@@ -1444,80 +1428,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
-
-[[package]]
-name = "web-sys"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "whoami"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ serde_json = "1.0"
 atty = "0.2.0"
 dirs = "4.0"
 
-whoami = "1.0"
-
 [target.'cfg(unix)'.dependencies]
 unix-daemonize = "0.1.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,8 +115,8 @@ fn main() {
         // fork to background by default
         if !matches.is_present("no-fork") {
             daemonize_redirect(
-                Some(format!("/tmp/nvim-gtk_stdout.{}.log", whoami::username())),
-                Some(format!("/tmp/nvim-gtk_stderr.{}.log", whoami::username())),
+                None::<String>,
+                None::<String>,
                 ChdirMode::NoChdir,
             )
             .unwrap();


### PR DESCRIPTION
When neovim-gtk starts and it daemonizes, it writes two temporary files into the `/tmp` directory based on the name of the user.  Unfortunately, this is insecure, since an attacker could create those files before us as symlinks pointing to a file they'd like us to write junk to, and then we would do exactly that.  The only secure way to create a temporary file is by using `O_EXCL`, and `unix_daemonize` doesn't do that.

On some Linux distros, this is prevented by `fs.protected_symlinks` and friends, but in general, we can't safely assume that the user has this flag enabled, and this wouldn't be true of other OSes where neovim-gtk might run, so let's just switch to redirecting to `/dev/null`.

We could do something like redirect to `.xsession-errors`, but that might not be present on Wayland. If someone really wants to see these messages, they can do so by running with `--no-fork`, but they probably don't care and just discarding them is fine.

Since we no longer need the `whoami` crate, remove it from `Cargo.toml` and `Cargo.lock`.

I originally reported this in a private email, since it's a security vulnerability, but got no response, so I'm opening a PR here.