### PR TITLE
popup_menu: Hide popup in an idle callback

### DIFF
--- a/src/popup_menu/mod.rs
+++ b/src/popup_menu/mod.rs
@@ -336,11 +336,14 @@ impl PopupMenu {
     }
 
     pub fn hide(&mut self) {
+        let popover = &self.popover;
         self.open = false;
-        // popdown() in case of fast hide/show
-        // situation does not work and just close popup window
-        // so hide() is important here
-        self.popover.hide();
+        glib::idle_add_local_once(clone!(popover => move || {
+            // popdown() in case of fast hide/show
+            // situation does not work and just close popup window
+            // so hide() is important here
+            popover.hide();
+        }));
     }
 
     pub fn select(&self, selected: Option<u32>) {


### PR DESCRIPTION
If we call GtkPopover::hide() directly, we'll potentially run into an re-entry issue causing a crash, as we can't re-borrow the State in the 'enter' pointor motion signal handler, since the state was already borrowed higher up in the backtrace.