### PR TITLE
shell: Use discrete scroll events

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1094,7 +1094,8 @@ impl Shell {
         state.nvim_viewport.add_controller(&focus_controller);
 
         let scroll_controller = gtk::EventControllerScroll::new(
-            gtk::EventControllerScrollFlags::BOTH_AXES
+            gtk::EventControllerScrollFlags::BOTH_AXES |
+            gtk::EventControllerScrollFlags::DISCRETE
         );
         scroll_controller.connect_scroll(clone!(
             state_ref, ui_state_ref => move |controller, dx, dy| {


### PR DESCRIPTION
This turns smooth scroll events from a touchpad to discrete scroll events, making their speed what you'd expect.