### PR TITLE
Disable default global keyboard shortcuts

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -201,6 +201,14 @@ impl Ui {
             window.set_decorated(false);
         }
 
+        // Override default shortcuts which are easy to press accidentally
+        if let Some(app) = window.application() {
+            app.set_accels_for_action("app.preferences", &[]);
+            app.set_accels_for_action("gtkinternal.hide", &[]);
+            app.set_accels_for_action("gtkinternal.hide-others", &[]);
+            app.set_accels_for_action("app.quit", &[]);
+        }
+
         let (update_subtitle, header_bar) = if use_header_bar {
             let (subscription, header_bar) = self.create_header_bar(app);
             (Some(subscription), Some(header_bar))


### PR DESCRIPTION
The default system menu is defined in gtk source files, and the relevant one for macOS is here: https://github.com/GNOME/gtk/blob/main/gtk/ui/gtkapplication-quartz.ui

By default, GTK automatically creates shortcuts (accels) for these actions, and they are bound by default to very common key combinations (ctrl+h to hide the window, for example), making many common keystrokes in vim nonfunctional.

This removes these default bindings, which seems to only affect macOS from what I can tell, as Linux global shortcuts are handled by the window manager and not individual windows. I'm unsure how or if this affects Windows, for whatever that's worth.