### PR TITLE
cursor: Don't show intermediate cursor positions to the user

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -65,6 +65,14 @@ impl GridMap {
             grid.model.clear_glyphs();
         }
     }
+
+    /// Flush any pending cursor position updates (e.g. updates we received before getting a 'flush'
+    /// event)
+    pub fn flush_cursor(&mut self) {
+        for grid in self.grids.values_mut() {
+            grid.flush_cursor();
+        }
+    }
 }
 
 pub struct Grid {
@@ -74,12 +82,16 @@ pub struct Grid {
 impl Grid {
     pub fn new() -> Self {
         Grid {
-            model: UiModel::empty(),
+            model: UiModel::default(),
         }
     }
 
     pub fn get_cursor(&self) -> (usize, usize) {
-        self.model.get_cursor()
+        self.model.get_real_cursor()
+    }
+
+    pub fn flush_cursor(&mut self) {
+        self.model.flush_cursor();
     }
 
     pub fn cur_point(&self) -> ModelRect {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1615,6 +1615,7 @@ impl State {
             self.nvim_viewport.clear_snapshot_cache();
         }
 
+        self.grids.flush_cursor();
         self.nvim_viewport.queue_draw();
     }
 

--- a/src/ui_model/model_layout.rs
+++ b/src/ui_model/model_layout.rs
@@ -51,7 +51,7 @@ impl ModelLayout {
 
     pub fn size(&self) -> (usize, usize) {
         (
-            max(self.cols_filled, self.model.get_cursor().1 + 1),
+            max(self.cols_filled, self.model.get_real_cursor().1 + 1),
             self.rows_filled,
         )
     }
@@ -60,7 +60,7 @@ impl ModelLayout {
         if rows > self.model.rows {
             let model_cols = self.model.columns;
             let model_rows = ((rows / (ModelLayout::ROWS_STEP + 1)) + 1) * ModelLayout::ROWS_STEP;
-            let (cur_row, cur_col) = self.model.get_cursor();
+            let (cur_row, cur_col) = self.model.get_real_cursor();
 
             let mut model = UiModel::new(model_rows as u64, model_cols as u64);
             self.model.swap_rows(&mut model, self.rows_filled - 1);
@@ -74,7 +74,7 @@ impl ModelLayout {
             return;
         }
 
-        let (row, col) = self.model.get_cursor();
+        let (row, col) = self.model.get_real_cursor();
 
         if shift {
             self.insert_into_lines(ch);
@@ -87,7 +87,7 @@ impl ModelLayout {
     fn insert_into_lines(&mut self, ch: String) {
         let line = &mut self.lines[0];
 
-        let cur_col = self.model.cur_col;
+        let (_, cur_col) = self.model.get_real_cursor();
 
         let mut col_idx = 0;
         for &mut (_, ref mut chars) in line {


### PR DESCRIPTION
While the rest of the ui_model is updated atomically through virtue of the fact we usually have a cached Snapshot to use in-between screen updates: the cursor is the only thing that isn't. This is mainly because we need to re-render the cursor position more often then the screen updates, in order to have a pulsing effect.