### PR TITLE
Run `cargo clippy --fix`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,6 @@ jobs:
 
       - name: Check that rust-fmt is happy
         run: podman run -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" -w ${GITHUB_WORKSPACE} neovim-gtk cargo fmt --check -v
+
+      - name: Check for clippy lints
+        run: podman run -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" -w ${GITHUB_WORKSPACE} neovim-gtk cargo clippy -- -Dwarnings

--- a/Containerfile.fedora
+++ b/Containerfile.fedora
@@ -1,5 +1,5 @@
 FROM fedora:37
 
 RUN dnf update -y
-RUN dnf install -y --nodocs --setopt=install_weak_deps=False rust cargo rustfmt atk-devel glib2-devel pango-devel gtk4-devel
+RUN dnf install -y --nodocs --setopt=install_weak_deps=False rust cargo rustfmt clippy atk-devel glib2-devel pango-devel gtk4-devel
 RUN dnf clean all

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn main() {
     }
 
     let path = Path::new(out_dir).join("key_map_table.rs");
-    let mut file = BufWriter::new(File::create(&path).unwrap());
+    let mut file = BufWriter::new(File::create(path).unwrap());
 
     writeln!(
         &mut file,
@@ -65,7 +65,7 @@ fn main() {
         .unwrap()
     );
 
-    if let Ok(output) = Command::new("git").args(&["rev-parse", "HEAD"]).output() {
+    if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
         println!(
             "cargo:rustc-env=GIT_COMMIT={}",
             String::from_utf8(output.stdout).unwrap()

--- a/src/cmd_line/mod.rs
+++ b/src/cmd_line/mod.rs
@@ -317,8 +317,8 @@ impl CmdLine {
             let state = state.borrow_mut();
             let nvim = state.nvim.as_ref().unwrap().nvim();
             let tree = controller.widget().downcast().unwrap();
-            if let Some(mut nvim) = nvim {
-                tree_button_press(&tree, x, y, &mut nvim, "");
+            if let Some(nvim) = nvim {
+                tree_button_press(&tree, x, y, &nvim, "");
             }
         }));
         tree.add_controller(&controller);

--- a/src/cmd_line/mod.rs
+++ b/src/cmd_line/mod.rs
@@ -336,11 +336,11 @@ impl CmdLine {
 
         if ctx.level_idx as usize == state.levels.len() {
             let level = state.levels.last_mut().unwrap();
-            level.replace_from_ctx(ctx, &*render_state);
-            level.update_cache(&*render_state);
+            level.replace_from_ctx(ctx, &render_state);
+            level.update_cache(&render_state);
         } else {
-            let mut level = Level::from_ctx(ctx, &*render_state);
-            level.update_cache(&*render_state);
+            let mut level = Level::from_ctx(ctx, &render_state);
+            level.update_cache(&render_state);
             state.levels.push(level);
         }
 
@@ -369,7 +369,7 @@ impl CmdLine {
 
         if let Some(level) = state.levels.get_mut((level - 1) as usize) {
             level.insert(c, shift, render_state);
-            level.update_cache(&*render_state);
+            level.update_cache(render_state);
         } else {
             error!("Level {} does not exists", level);
         }
@@ -394,8 +394,8 @@ impl CmdLine {
     pub fn show_block(&mut self, content: &Vec<Vec<(u64, String)>>, max_width: i32) {
         let mut state = self.state.borrow_mut();
         let mut block =
-            Level::from_multiline_content(content, max_width, &*state.render_state.borrow());
-        block.update_cache(&*state.render_state.borrow());
+            Level::from_multiline_content(content, max_width, &state.render_state.borrow());
+        block.update_cache(&state.render_state.borrow());
         state.block = Some(block);
         state.request_area_size();
     }
@@ -408,8 +408,8 @@ impl CmdLine {
 
             let block = state.block.as_mut().unwrap();
             block.replace_line(attr_content, true);
-            block.update_preferred_size(&*render_state.borrow());
-            block.update_cache(&*render_state.borrow());
+            block.update_preferred_size(&render_state.borrow());
+            block.update_cache(&render_state.borrow());
         }
         state.request_area_size();
     }
@@ -486,7 +486,7 @@ impl CmdLine {
         if selected >= 0 {
             let wild_tree = self.wild_tree.clone();
             glib::idle_add_local_once(move || {
-                let selected_path = gtk::TreePath::from_string(&format!("{}", selected)).unwrap();
+                let selected_path = gtk::TreePath::from_string(&format!("{selected}")).unwrap();
                 wild_tree.selection().select_path(&selected_path);
                 wild_tree.scroll_to_cell(
                     Some(&selected_path),
@@ -527,10 +527,8 @@ impl<'a> CmdLineContext<'a> {
 
         if content.is_empty() {
             content.push(content_line.remove(0));
-        } else {
-            if let Some(line) = content.last_mut() {
-                line.extend(content_line.remove(0))
-            }
+        } else if let Some(line) = content.last_mut() {
+            line.extend(content_line.remove(0))
         }
 
         LineContent {
@@ -639,7 +637,7 @@ fn update_css(css_provider: &gtk::CssProvider, hl: &HighlightMap) {
     let fg = hl.pmenu_fg_sel();
 
     css_provider.load_from_data(
-        &format!(
+        format!(
             ".view :selected {{ color: {}; background-color: {};}}\n
                 .view {{ background-color: {}; }}",
             fg.to_hex(),

--- a/src/cmd_line/viewport.rs
+++ b/src/cmd_line/viewport.rs
@@ -144,7 +144,7 @@ impl WidgetImpl for CmdlineViewportObject {
 
         if let Some(block) = state.block.as_mut() {
             if inner.block_cache.is_none() {
-                inner.block_cache = snapshot_nvim(font_ctx, &mut block.model_layout.model, hl);
+                inner.block_cache = snapshot_nvim(font_ctx, &block.model_layout.model, hl);
             }
             if let Some(ref cache) = inner.block_cache {
                 snapshot.append_node(cache);
@@ -155,7 +155,7 @@ impl WidgetImpl for CmdlineViewportObject {
 
         if let Some(level) = state.levels.last_mut() {
             if inner.level_cache.is_none() {
-                inner.level_cache = snapshot_nvim(font_ctx, &mut level.model_layout.model, hl);
+                inner.level_cache = snapshot_nvim(font_ctx, &level.model_layout.model, hl);
             }
             if let Some(ref cache) = inner.level_cache {
                 snapshot.append_node(cache);

--- a/src/cmd_line/viewport.rs
+++ b/src/cmd_line/viewport.rs
@@ -94,7 +94,7 @@ impl ObjectImpl for CmdlineViewportObject {
                     Arc::downgrade(&value.get::<glib::BoxedAnyObject>().unwrap().borrow());
             }
             "snapshot-cached" => {
-                if value.get::<bool>().unwrap() == false {
+                if !value.get::<bool>().unwrap() {
                     let mut inner = self.inner.borrow_mut();
                     inner.block_cache = None;
                     inner.level_cache = None;

--- a/src/color.rs
+++ b/src/color.rs
@@ -68,7 +68,7 @@ impl Color {
     }
 
     pub fn fade<'a>(&'a self, into: &'a Self, percentage: f64) -> Cow<Self> {
-        debug_assert!(percentage >= 0.0 && percentage <= 1.0);
+        debug_assert!((0.0..=1.0).contains(&percentage));
 
         match percentage {
             _ if percentage <= 0.000001 => Cow::Borrowed(self),

--- a/src/color.rs
+++ b/src/color.rs
@@ -30,7 +30,7 @@ impl Color {
         Color(r / 255.0, g / 255.0, b / 255.0)
     }
 
-    pub fn to_u16(&self) -> (u16, u16, u16) {
+    pub fn to_u16(self) -> (u16, u16, u16) {
         (
             (std::u16::MAX as f64 * self.0) as u16,
             (std::u16::MAX as f64 * self.1) as u16,
@@ -38,7 +38,7 @@ impl Color {
         )
     }
 
-    pub fn to_hex(&self) -> String {
+    pub fn to_hex(self) -> String {
         format!(
             "#{:02X}{:02X}{:02X}",
             (self.0 * 255.0) as u8,
@@ -47,17 +47,17 @@ impl Color {
         )
     }
 
-    pub fn to_rgbo(&self, alpha: f64) -> gdk::RGBA {
+    pub fn to_rgbo(self, alpha: f64) -> gdk::RGBA {
         gdk::RGBA::new(self.0 as f32, self.1 as f32, self.2 as f32, alpha as f32)
     }
 
-    pub fn to_pango_bg(&self) -> pango::AttrColor {
+    pub fn to_pango_bg(self) -> pango::AttrColor {
         let (r, g, b) = self.to_u16();
 
         pango::AttrColor::new_background(r, g, b)
     }
 
-    pub fn to_pango_fg(&self) -> pango::AttrColor {
+    pub fn to_pango_fg(self) -> pango::AttrColor {
         let (r, g, b) = self.to_u16();
 
         pango::AttrColor::new_foreground(r, g, b)

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -247,11 +247,7 @@ impl<CB: CursorRedrawCb + 'static> Cursor<CB> {
             return false;
         }
 
-        if state.alpha.0 < 0.000001 {
-            false
-        } else {
-            true
-        }
+        state.alpha.0 >= 0.000001
     }
 
     pub fn is_focused(&self) -> bool {

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 pub fn get_app_config_dir_create() -> Result<PathBuf, String> {
     let config_dir = get_app_config_dir()?;
 
-    std::fs::create_dir_all(&config_dir).map_err(|e| format!("{}", e))?;
+    std::fs::create_dir_all(&config_dir).map_err(|e| format!("{e}"))?;
 
     Ok(config_dir)
 }

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -200,7 +200,7 @@ impl FileBrowserWidget {
 
     pub fn init(&mut self) {
         // Initialize values.
-        if let Some(dir) = get_current_dir(&mut self.nvim().unwrap()) {
+        if let Some(dir) = get_current_dir(&self.nvim().unwrap()) {
             update_dir_list(&dir, &self.comps.dir_list_model, &self.comps.dir_list);
             self.state.borrow_mut().current_dir = dir;
         }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -135,7 +135,7 @@ impl HighlightMap {
         hl: &HashMap<String, Value>,
         info: &[HashMap<String, Value>],
     ) -> HighlightUpdates {
-        let hl = Rc::new(Highlight::from_value_map(&hl));
+        let hl = Rc::new(Highlight::from_value_map(hl));
         let mut updates = HighlightUpdates::default();
 
         for item in info {
@@ -284,7 +284,7 @@ impl Highlight {
     pub fn from_value_map(attrs: &HashMap<String, Value>) -> Self {
         let mut model_attrs = Highlight::new();
 
-        for (ref key, ref val) in attrs {
+        for (ref key, val) in attrs {
             match key.as_ref() {
                 "foreground" => {
                     if let Some(fg) = val.as_u64() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -60,7 +60,7 @@ pub fn keyval_to_input_string(in_str: &str, in_state: gdk::ModifierType) -> Stri
     let input = [mod_chars.as_slice(), &[val]].concat().join(sep);
 
     if !empty && input.chars().count() > 1 {
-        format!("<{}>", input)
+        format!("<{input}>")
     } else {
         input
     }
@@ -73,11 +73,9 @@ pub fn convert_key(keyval: gdk::Key, modifiers: gdk::ModifierType) -> Option<Str
         }
     }
 
-    if let Some(ch) = keyval.to_unicode() {
-        Some(keyval_to_input_string(&ch.to_string(), modifiers))
-    } else {
-        None
-    }
+    keyval
+        .to_unicode()
+        .map(|ch| keyval_to_input_string(&ch.to_string(), modifiers))
 }
 
 pub fn im_input(nvim: &NvimSession, input: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
 #![windows_subsystem = "windows"]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::comparison_chain)]
+#![allow(clippy::await_holding_refcell_ref)]
 
 mod color;
 mod dirs;

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -37,7 +37,7 @@ pub fn split_at_comma(source: &str) -> Vec<String> {
 }
 
 /// Escape special ASCII characters with a backslash.
-pub fn escape_filename<'t>(filename: &'t str) -> Cow<'t, str> {
+pub fn escape_filename(filename: &str) -> Cow<str> {
     static SPECIAL_CHARS: Lazy<Regex> = Lazy::new(|| {
         if cfg!(target_os = "windows") {
             // On Windows, don't escape `:` and `\`, as these are valid components of the path.

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -47,7 +47,7 @@ pub fn escape_filename<'t>(filename: &'t str) -> Cow<'t, str> {
             Regex::new(r"[[:ascii:]&&[^0-9a-zA-Z._/-]]").unwrap()
         }
     });
-    SPECIAL_CHARS.replace_all(&*filename, r"\$0")
+    SPECIAL_CHARS.replace_all(filename, r"\$0")
 }
 
 /// Decode a file URI.
@@ -62,7 +62,7 @@ pub fn decode_uri(uri: &str) -> Option<String> {
     let path = percent_decode(path.as_bytes()).decode_utf8().ok()?;
     if cfg!(target_os = "windows") {
         static SLASH: Lazy<Regex> = Lazy::new(|| Regex::new(r"/").unwrap());
-        Some(String::from(SLASH.replace_all(&*path, r"\")))
+        Some(String::from(SLASH.replace_all(&path, r"\")))
     } else {
         Some("/".to_owned() + &path)
     }

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -2,7 +2,7 @@ use log::error;
 use nvim_rs::Value;
 use std::collections::HashMap;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum NvimMode {
     Normal,
     Insert,
@@ -51,7 +51,7 @@ impl Mode {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CursorShape {
     Block,
     Horizontal,
@@ -77,7 +77,7 @@ impl CursorShape {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ModeInfo {
     cursor_shape: Option<CursorShape>,
     cell_percentage: Option<u64>,

--- a/src/nvim/client.rs
+++ b/src/nvim/client.rs
@@ -31,13 +31,13 @@ impl NeovimApiInfo {
 
         let metadata = match api_info.next().ok_or("Metadata is missing")? {
             Value::Map(pairs) => Ok(pairs),
-            v @ _ => Err(format!("Metadata is wrong type, got {:?}", v)),
+            v => Err(format!("Metadata is wrong type, got {v:?}")),
         }?;
 
         for (key, value) in metadata.into_iter() {
             match key
                 .as_str()
-                .ok_or(format!("Metadata key {:?} isn't string", key))?
+                .ok_or(format!("Metadata key {key:?} isn't string"))?
             {
                 "ui_options" => self_.parse_ui_options(value)?,
                 "functions" => self_.parse_functions(value)?,
@@ -51,11 +51,11 @@ impl NeovimApiInfo {
     fn parse_ui_options(&mut self, extensions: Value) -> Result<(), String> {
         for extension in extensions
             .as_array()
-            .ok_or(format!("UI option list is invalid: {:?}", extensions))?
+            .ok_or(format!("UI option list is invalid: {extensions:?}"))?
         {
             match extension
                 .as_str()
-                .ok_or(format!("UI option isn't string: {:?}", extensions))?
+                .ok_or(format!("UI option isn't string: {extensions:?}"))?
             {
                 "ext_cmdline" => self.ext_cmdline = true,
                 "ext_wildmenu" => self.ext_wildmenu = true,
@@ -74,18 +74,18 @@ impl NeovimApiInfo {
     fn parse_functions(&mut self, functions: Value) -> Result<(), String> {
         for function in functions
             .as_array()
-            .ok_or_else(|| format!("Function list is not a list: {:?}", functions))?
+            .ok_or_else(|| format!("Function list is not a list: {functions:?}"))?
         {
             match function
                 .as_map()
-                .ok_or_else(|| format!("Function info is not a map: {:?}", function))?
-                .into_iter()
+                .ok_or_else(|| format!("Function info is not a map: {function:?}"))?
+                .iter()
                 .find_map(|(key, value)| {
                     key.as_str()
                         .filter(|k| *k == "name")
                         .and_then(|_| value.as_str())
                 })
-                .ok_or_else(|| format!("Function info is missing name: {:?}", functions))?
+                .ok_or_else(|| format!("Function info is missing name: {functions:?}"))?
             {
                 "nvim_ui_pum_set_height" => self.ui_pum_set_height = true,
                 "nvim_ui_pum_set_bounds" => self.ui_pum_set_bounds = true,

--- a/src/nvim/handler.rs
+++ b/src/nvim/handler.rs
@@ -41,9 +41,7 @@ impl NvimHandler {
                                 let ui = &mut ui.borrow_mut();
                                 redraw_handler::call_gui_event(
                                     ui,
-                                    ev_name
-                                        .as_str()
-                                        .ok_or_else(|| "Event name does not exists")?,
+                                    ev_name.as_str().ok_or("Event name does not exists")?,
                                     args,
                                 )?;
                                 ui.queue_draw(RedrawMode::All);
@@ -88,9 +86,7 @@ impl NvimHandler {
                                 sender
                                     .send(redraw_handler::call_gui_request(
                                         &ui.clone(),
-                                        req_name
-                                            .as_str()
-                                            .ok_or_else(|| "Event name does not exists")?,
+                                        req_name.as_str().ok_or("Event name does not exists")?,
                                         &args,
                                     ))
                                     .unwrap();
@@ -177,7 +173,7 @@ fn call_redraw_handler(
             let (call_repaint_mode, call_popupmenu) =
                 match redraw_handler::call(&mut ui_ref, ev_name, args) {
                     Ok(mode) => mode,
-                    Err(desc) => return Err(format!("Event {}\n{}", ev_name, desc)),
+                    Err(desc) => return Err(format!("Event {ev_name}\n{desc}")),
                 };
             repaint_mode = repaint_mode.max(call_repaint_mode);
             pending_popupmenu.update(call_popupmenu);

--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -380,7 +380,7 @@ pub fn start<'a>(
         .arg("--cmd")
         .arg(&format!(
             "let &rtp.=',{}'",
-            env::var("NVIM_GTK_RUNTIME_PATH").unwrap_or(env!("RUNTIME_PATH").into())
+            env::var("NVIM_GTK_RUNTIME_PATH").unwrap_or_else(|_| env!("RUNTIME_PATH").into())
         ))
         .stderr(Stdio::inherit())
         .stdin(Stdio::piped())

--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -65,7 +65,7 @@ impl NvimInitError {
         E: Into<Box<dyn error::Error>>,
     {
         NvimInitError::ResponseError {
-            cmd: Some(format!("{:?}", cmd)),
+            cmd: Some(format!("{cmd:?}")),
             source: error.into(),
         }
     }
@@ -76,7 +76,7 @@ impl NvimInitError {
 
     pub fn source(&self) -> String {
         match self {
-            Self::ResponseError { source, .. } => format!("{}", source),
+            Self::ResponseError { source, .. } => format!("{source}"),
             Self::MissingCapability(_) => "".to_string(),
         }
     }
@@ -93,9 +93,9 @@ impl NvimInitError {
 impl fmt::Display for NvimInitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::ResponseError { source, .. } => write!(f, "{:?}", source),
+            Self::ResponseError { source, .. } => write!(f, "{source:?}"),
             Self::MissingCapability(cap) => {
-                write!(f, "Nvim version is too old, missing support for {}", cap)
+                write!(f, "Nvim version is too old, missing support for {cap}")
             }
         }
     }
@@ -133,8 +133,8 @@ impl error::Error for SessionError {
 impl fmt::Display for SessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::CallError(e) => write!(f, "{:?}", e),
-            Self::TimeoutError(e) => write!(f, "{:?}", e),
+            Self::CallError(e) => write!(f, "{e:?}"),
+            Self::TimeoutError(e) => write!(f, "{e:?}"),
         }
     }
 }
@@ -302,7 +302,7 @@ impl NvimSession {
             .report_err();
 
         let res = self
-            .timeout(self.command(&format!("cal chanclose({})", channel)))
+            .timeout(self.command(&format!("cal chanclose({channel})")))
             .await;
         if let Err(ref e) = res {
             if let SessionError::CallError(ref e) = *e {
@@ -319,7 +319,7 @@ impl NvimSession {
 
     /// A helper for checking if nvim is currently blocked waiting on user input or not
     pub fn is_blocked(&self) -> bool {
-        let &(_, ref blocked) = &self.block_on(self.get_mode()).unwrap()[1];
+        let (_, blocked) = &self.block_on(self.get_mode()).unwrap()[1];
 
         blocked.as_bool().unwrap()
     }
@@ -391,7 +391,7 @@ pub fn start<'a>(
 
     if let Some(nvim_config) = NvimConfig::config_path() {
         if let Some(path) = nvim_config.to_str() {
-            cmd.arg("--cmd").arg(format!("source {}", path));
+            cmd.arg("--cmd").arg(format!("source {path}"));
         }
     }
 

--- a/src/nvim/redraw_handler.rs
+++ b/src/nvim/redraw_handler.rs
@@ -301,14 +301,10 @@ pub fn call_gui_event(
                         .map_err(|e: ParseFloatError| e.to_string())?,
                 )),
                 "PreferDarkTheme" => {
-                    let prefer_dark_theme = match try_str!(args
-                        .get(1)
-                        .cloned()
-                        .unwrap_or_else(|| Value::from("off")))
-                    {
-                        "on" => true,
-                        _ => false,
-                    };
+                    let prefer_dark_theme = matches!(
+                        try_str!(args.get(1).cloned().unwrap_or_else(|| Value::from("off"))),
+                        "on"
+                    );
 
                     ui.on_command(NvimCommand::PreferDarkTheme(prefer_dark_theme))
                 }
@@ -349,7 +345,7 @@ pub fn call_gui_request(
                     let t = glib::MainContext::default()
                         .block_on(clipboard.read_text_future())
                         .unwrap_or(None)
-                        .unwrap_or("".into());
+                        .unwrap_or_else(|| "".into());
 
                     Ok(Value::Array(
                         t.split('\n').map(|s| s.into()).collect::<Vec<Value>>(),
@@ -472,7 +468,7 @@ pub fn call(
 }
 
 /// Represents the next pending popup menu action before we've actually performed a redraw
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum PendingPopupMenu {
     Show {
         items: Vec<PopupMenuItem>,

--- a/src/nvim/redraw_handler.rs
+++ b/src/nvim/redraw_handler.rs
@@ -190,8 +190,7 @@ fn set_ui_opt(nvim: &NvimSession, opts: &[(&str, bool)], enable: bool) -> Result
         if !supported {
             return if enable {
                 Err(format!(
-                    "{} is not supported by your version of neovim, please update!",
-                    ext
+                    "{ext} is not supported by your version of neovim, please update!"
                 ))
             } else {
                 Ok(())
@@ -315,18 +314,15 @@ pub fn call_gui_event(
                 }
                 "SetCursorBlink" => {
                     let blink_count =
-                        match try_str!(args.get(1).cloned().unwrap_or_else(|| Value::from(-1)))
+                        try_str!(args.get(1).cloned().unwrap_or_else(|| Value::from(-1)))
                             .parse::<i32>()
-                        {
-                            Ok(val) => val,
-                            Err(_) => -1,
-                        };
+                            .unwrap_or(-1);
                     ui.set_cursor_blink(blink_count);
                 }
                 _ => error!("Unknown command"),
             };
         }
-        _ => return Err(format!("Unsupported event {}({:?})", method, args)),
+        _ => return Err(format!("Unsupported event {method}({args:?})")),
     }
     Ok(())
 }
@@ -359,10 +355,10 @@ pub fn call_gui_request(
                         t.split('\n').map(|s| s.into()).collect::<Vec<Value>>(),
                     ))
                 }
-                opt => Err(format!("Unknown option: {}", opt).into()),
+                opt => Err(format!("Unknown option: {opt}").into()),
             }
         }
-        _ => Err(format!("Unsupported request {}({:?})", method, args).into()),
+        _ => Err(format!("Unsupported request {method}({args:?})").into()),
     }
 }
 
@@ -546,7 +542,7 @@ mod tests {
         };
 
         let mut test_val = PendingPopupMenu::Select(None);
-        test_val.update(SHOW.clone());
+        test_val.update(SHOW);
         assert_eq!(test_val, SHOW);
 
         test_val.update(PendingPopupMenu::None);

--- a/src/nvim_config.rs
+++ b/src/nvim_config.rs
@@ -54,16 +54,16 @@ impl NvimConfig {
             .write(true)
             .truncate(true)
             .open(&config_dir)
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
 
         let content = &self.plug_config.as_ref().unwrap().source;
         if !content.is_empty() {
             debug!("{}", content);
             file.write_all(content.as_bytes())
-                .map_err(|e| format!("{}", e))?;
+                .map_err(|e| format!("{e}"))?;
         }
 
-        file.sync_all().map_err(|e| format!("{}", e))?;
+        file.sync_all().map_err(|e| format!("{e}"))?;
         Ok(config_dir)
     }
 }

--- a/src/nvim_viewport.rs
+++ b/src/nvim_viewport.rs
@@ -143,7 +143,7 @@ impl ObjectImpl for NvimViewportObject {
                     Arc::downgrade(&value.get::<glib::BoxedAnyObject>().unwrap().borrow());
             }
             "snapshot-cached" => {
-                if value.get::<bool>().unwrap() == false {
+                if !value.get::<bool>().unwrap() {
                     self.inner.borrow_mut().snapshot_cache = None;
                 }
             }

--- a/src/plug_manager/store.rs
+++ b/src/plug_manager/store.rs
@@ -93,7 +93,7 @@ impl Store {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 struct Settings {
     enabled: bool,
     plugs: Vec<PlugInfo>,
@@ -108,20 +108,11 @@ impl Settings {
     }
 }
 
-impl Default for Settings {
-    fn default() -> Self {
-        Settings {
-            plugs: vec![],
-            enabled: false,
-        }
-    }
-}
-
 impl SettingsLoader for Settings {
     const SETTINGS_FILE: &'static str = "plugs.toml";
 
     fn from_str(s: &str) -> Result<Self, String> {
-        toml::from_str(&s).map_err(|e| format!("{}", e))
+        toml::from_str(s).map_err(|e| format!("{e}"))
     }
 }
 

--- a/src/plug_manager/vim_plug.rs
+++ b/src/plug_manager/vim_plug.rs
@@ -25,7 +25,7 @@ impl Manager {
         if let Some(nvim) = self.nvim() {
             let g_plugs = nvim
                 .block_timeout(nvim.eval("g:plugs"))
-                .map_err(|e| format!("Can't retrive g:plugs map: {}", e))?;
+                .map_err(|e| format!("Can't retrive g:plugs map: {e}"))?;
 
             let plugs_map = g_plugs
                 .as_map()
@@ -34,7 +34,7 @@ impl Manager {
 
             let g_plugs_order = nvim
                 .block_timeout(nvim.eval("g:plugs_order"))
-                .map_err(|e| format!("{}", e))?;
+                .map_err(|e| format!("{e}"))?;
 
             let order_arr = g_plugs_order
                 .as_array()
@@ -51,11 +51,7 @@ impl Manager {
                             .and_then(|desc| desc.to_attrs_map().ok())
                             .and_then(|desc| {
                                 let uri = desc.get("uri").and_then(|uri| uri.as_str());
-                                if let Some(uri) = uri {
-                                    Some(VimPlugInfo::new(name.to_owned(), uri.to_owned()))
-                                } else {
-                                    None
-                                }
+                                uri.map(|uri| VimPlugInfo::new(name.to_owned(), uri.to_owned()))
                             })
                     } else {
                         None
@@ -83,7 +79,7 @@ impl Manager {
     pub fn reload(&self, path: &str) {
         let path = path.to_owned();
         if let Some(nvim) = self.nvim() {
-            spawn_timeout!(nvim.command(&format!("source {}", path)));
+            spawn_timeout!(nvim.command(&format!("source {path}")));
         }
     }
 }

--- a/src/plug_manager/vimawesome.rs
+++ b/src/plug_manager/vimawesome.rs
@@ -47,7 +47,7 @@ fn request(query: Option<&str>) -> io::Result<DescriptionList> {
             format!(
                 "curl exit with error:\n{}",
                 match out.status.code() {
-                    Some(code) => format!("Exited with status code: {}", code),
+                    Some(code) => format!("Exited with status code: {code}"),
                     None => "Process terminated by signal".to_owned(),
                 }
             ),
@@ -132,7 +132,7 @@ fn create_plug_label(plug: &Description) -> gtk::Box {
     name_lbl.set_halign(gtk::Align::Start);
     let url_lbl = gtk::Label::new(None);
     if let Some(url) = plug.github_url.as_ref() {
-        url_lbl.set_markup(&format!("<a href=\"{}\">{}</a>", url, url));
+        url_lbl.set_markup(&format!("<a href=\"{url}\">{url}</a>"));
     }
     url_lbl.set_halign(gtk::Align::Start);
 

--- a/src/popup_menu/list_row.rs
+++ b/src/popup_menu/list_row.rs
@@ -20,7 +20,7 @@ impl PopupMenuListRow {
     }
 
     pub fn set_row(&self, row: Option<&PopupMenuItemRef>) {
-        self.set_property("row", row.cloned().map(|r| glib::BoxedAnyObject::new(r)));
+        self.set_property("row", row.cloned().map(glib::BoxedAnyObject::new));
     }
 }
 

--- a/src/popup_menu/mod.rs
+++ b/src/popup_menu/mod.rs
@@ -127,7 +127,7 @@ impl State {
         self.info_scroll.set_max_content_width(max_width);
         self.item_scroll.set_max_content_width(max_width);
         self.item_scroll
-            .set_max_content_height(self.row_height as i32 * MAX_VISIBLE_ROWS);
+            .set_max_content_height(self.row_height * MAX_VISIBLE_ROWS);
         self.item_scroll.hadjustment().set_value(0.0);
 
         self.select(selected);
@@ -167,13 +167,13 @@ impl State {
          */
 
         let layout = ctx.font_ctx.create_layout();
-        layout.set_text(&max_word);
+        layout.set_text(max_word);
         let (word_max_width, _) = layout.pixel_size();
         let word_column_width = word_max_width + DEFAULT_PADDING;
 
         let mut row_state = self.list_row_state.borrow_mut();
         if !max_kind.is_empty() {
-            layout.set_text(&max_kind);
+            layout.set_text(max_kind);
             let (mut kind_width, _) = layout.pixel_size();
 
             kind_width += DEFAULT_PADDING;
@@ -188,7 +188,7 @@ impl State {
             let space_left =
                 ctx.max_width - row_state.word_col_width - row_state.kind_col_width.unwrap_or(0);
 
-            layout.set_text(&max_menu);
+            layout.set_text(max_menu);
             row_state.menu_col_width =
                 Some((layout.pixel_size().0 + DEFAULT_PADDING).min(space_left));
         } else {
@@ -233,7 +233,7 @@ impl State {
         let font_desc = font_ctx.font_description();
 
         self.css_provider.load_from_data(
-            &format!(
+            format!(
                 "listview.nvim-popupmenu-list {{\
                     background-color: {bg};\
                     font-family: \"{font}\";\

--- a/src/project.rs
+++ b/src/project.rs
@@ -155,7 +155,7 @@ impl Projects {
             .connect_row_activated(clone!(projects => move |tree, _, column| {
                 // Don't activate if the user clicked the checkbox.
                 let toggle_column = tree.column(2).unwrap();
-                if column.as_deref() == Some(&toggle_column) {
+                if column == Some(&toggle_column) {
                     return;
                 }
                 let selection = tree.selection();
@@ -450,7 +450,7 @@ impl EntryStore {
         match nvim.block_timeout(nvim.call_function("getcwd", vec![])) {
             Ok(pwd) => {
                 if let Some(pwd) = pwd.as_str() {
-                    if entries.iter().find(|e| e.project && e.uri == pwd).is_none() {
+                    if !entries.iter().any(|e| e.project && e.uri == pwd) {
                         entries.insert(0, Entry::new_current_project(pwd));
                     }
                 } else {
@@ -628,7 +628,7 @@ impl SettingsLoader for ProjectSettings {
     const SETTINGS_FILE: &'static str = "projects.toml";
 
     fn from_str(s: &str) -> Result<Self, String> {
-        toml::from_str(&s).map_err(|e| format!("{}", e))
+        toml::from_str(s).map_err(|e| format!("{e}"))
     }
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -282,8 +282,8 @@ impl Projects {
         let shell_state = shell_borrow.state.borrow_mut();
 
         let nvim = shell_state.nvim();
-        if let Some(mut nvim) = nvim {
-            let store = EntryStore::load(&mut nvim);
+        if let Some(nvim) = nvim {
+            let store = EntryStore::load(&nvim);
             store.populate(&self.get_list_store(), None);
             self.store = Some(store);
         }

--- a/src/render/context.rs
+++ b/src/render/context.rs
@@ -103,7 +103,7 @@ impl Context {
                     seen.insert(font_desc);
                 }
 
-                pango_context.set_font_description(Some(&our_font));
+                pango_context.set_font_description(Some(our_font));
                 new_res.unwrap_or(first_res)
             })
             .collect()
@@ -235,10 +235,10 @@ impl CellMetrics {
         (x, y, w, h): (f64, f64, f64, f64),
     ) -> (f64, f64, f64, f64) {
         (
-            x as f64 / self.char_width,
-            y as f64 / self.line_height,
-            w as f64 / self.char_width,
-            h as f64 / self.line_height,
+            x / self.char_width,
+            y / self.line_height,
+            w / self.char_width,
+            h / self.line_height,
         )
     }
 

--- a/src/render/itemize.rs
+++ b/src/render/itemize.rs
@@ -85,15 +85,9 @@ impl<'a> Iterator for ItemizeIterator<'a> {
             }
         };
 
-        if let Some(start_index) = start_index {
-            Some(ItemizeResult::new(
-                start_index,
-                end_index - start_index,
-                avoid_break,
-            ))
-        } else {
-            None
-        }
+        start_index.map(|start_index| {
+            ItemizeResult::new(start_index, end_index - start_index, avoid_break)
+        })
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -205,7 +205,7 @@ pub fn snapshot_cursor<T: CursorRedrawCb + 'static>(
         (x, y),
         cell,
         double_width,
-        &hl,
+        hl,
         fade_percentage,
         alpha,
     );
@@ -451,7 +451,7 @@ fn snapshot_cell(
 
         if item.glyphs().is_some() {
             if let Some(render_node) =
-                item.render_node(fg.into(), (x as f32, (y + cell_metrics.ascent) as f32))
+                item.render_node(fg, (x as f32, (y + cell_metrics.ascent) as f32))
             {
                 snapshot.append_node(render_node);
             }
@@ -478,7 +478,7 @@ pub fn shape_dirty(ctx: &context::Context, ui_model: &mut ui_model::UiModel, hl:
                         let offset = item.item.offset() as usize;
                         let length = item.item.length() as usize;
                         if let Some(line_str) = styled_line.line_str.get(offset..offset + length) {
-                            pango::shape(&line_str, analysis, &mut glyphs);
+                            pango::shape(line_str, analysis, &mut glyphs);
                         } else {
                             warn!("Wrong itemize split");
                         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -71,14 +71,12 @@ impl Settings {
     pub fn init(&mut self) {
         let shell = Weak::upgrade(self.shell.as_ref().unwrap()).unwrap();
         let state = self.state.clone();
-        self.state
-            .borrow_mut()
-            .update_font(&mut *shell.borrow_mut());
+        self.state.borrow_mut().update_font(&mut shell.borrow_mut());
         self.state
             .borrow()
             .gnome_interface_settings
             .connect_changed(None, move |_, _| {
-                monospace_font_changed(&mut *shell.borrow_mut(), &mut *state.borrow_mut())
+                monospace_font_changed(&mut shell.borrow_mut(), &mut state.borrow_mut())
             });
     }
 
@@ -91,10 +89,10 @@ impl Settings {
 }
 
 #[cfg(unix)]
-fn monospace_font_changed(mut shell: &mut Shell, state: &mut State) {
+fn monospace_font_changed(shell: &mut Shell, state: &mut State) {
     // rpc is priority for font
     if state.font_source != FontSource::Rpc {
-        state.update_font(&mut shell);
+        state.update_font(shell);
     }
 }
 
@@ -138,10 +136,10 @@ pub trait SettingsLoader: Sized + serde::Serialize + Default {
 
 fn load_from_file<T: SettingsLoader>(path: &Path) -> Result<T, String> {
     if path.exists() {
-        let mut file = File::open(path).map_err(|e| format!("{}", e))?;
+        let mut file = File::open(path).map_err(|e| format!("{e}"))?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
         T::from_str(&contents)
     } else {
         Ok(Default::default())
@@ -157,11 +155,11 @@ fn load_err<T: SettingsLoader>() -> Result<T, String> {
 fn save_err<T: SettingsLoader>(sl: &T) -> Result<(), String> {
     let mut toml_path = dirs::get_app_config_dir_create()?;
     toml_path.push(T::SETTINGS_FILE);
-    let mut file = File::create(toml_path).map_err(|e| format!("{}", e))?;
+    let mut file = File::create(toml_path).map_err(|e| format!("{e}"))?;
 
-    let contents = toml::to_vec::<T>(sl).map_err(|e| format!("{}", e))?;
+    let contents = toml::to_vec::<T>(sl).map_err(|e| format!("{e}"))?;
 
-    file.write_all(&contents).map_err(|e| format!("{}", e))?;
+    file.write_all(&contents).map_err(|e| format!("{e}"))?;
 
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,7 @@ use crate::shell::Shell;
 #[cfg(unix)]
 use gio::{self, prelude::*};
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum FontSource {
     Rpc,
     #[cfg(unix)]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -488,8 +488,8 @@ impl State {
     }
 
     fn im_commit(&self, ch: &str) {
-        if let Some(mut nvim) = self.nvim() {
-            input::im_input(&mut nvim, ch);
+        if let Some(nvim) = self.nvim() {
+            input::im_input(&nvim, ch);
         }
     }
 
@@ -654,7 +654,7 @@ impl State {
     pub fn run_now(&self, handle: &SubscriptionHandle) {
         self.subscriptions
             .borrow()
-            .run_now(handle, &mut self.nvim().unwrap());
+            .run_now(handle, &self.nvim().unwrap());
     }
 
     pub fn set_font(&mut self, font_desc: String) {
@@ -1038,7 +1038,7 @@ impl Shell {
         click_controller.connect_pressed(clone!(
             state_ref, ui_state_ref, menu => move |controller, _, x, y| {
                 gtk_button_press(
-                    &mut state_ref.borrow_mut(),
+                    &state_ref.borrow_mut(),
                     &ui_state_ref,
                     get_button(controller),
                     x,

--- a/src/shell_dlg.rs
+++ b/src/shell_dlg.rs
@@ -101,7 +101,7 @@ async fn show_not_saved_dlg(
             }
         }
         gtk::ResponseType::No => true,
-        gtk::ResponseType::Cancel | _ => false,
+        _ => false,
     };
 
     dlg.close();

--- a/src/shell_dlg.rs
+++ b/src/shell_dlg.rs
@@ -32,7 +32,7 @@ pub fn can_close_window(
                     glib::MainContext::default().spawn_local(async move {
                         let res = {
                             let mut comps = comps.borrow_mut();
-                            let res = show_not_saved_dlg(&*comps, shell, &vec).await;
+                            let res = show_not_saved_dlg(&comps, shell, &vec).await;
 
                             comps.exit_confirmed = res;
                             res
@@ -74,7 +74,7 @@ async fn show_not_saved_dlg(
         flags,
         MessageType::Question,
         ButtonsType::None,
-        &format!("Save changes to '{}'?", changed_files),
+        &format!("Save changes to '{changed_files}'?"),
     );
 
     dlg.add_buttons(&[

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -121,10 +121,9 @@ impl Subscriptions {
                 let args = subscription
                     .args
                     .iter()
-                    .fold("".to_owned(), |acc, arg| acc + ", " + &arg);
+                    .fold("".to_owned(), |acc, arg| acc + ", " + arg);
                 let autocmd = format!(
-                    "autocmd {} {} call rpcnotify(1, 'subscription', '{}', '{}', {} {})",
-                    event_name, pattern, event_name, pattern, i, args,
+                    "autocmd {event_name} {pattern} call rpcnotify(1, 'subscription', '{event_name}', '{pattern}', {i} {args})",
                 );
                 spawn_timeout!(nvim.command(&autocmd));
             }
@@ -188,7 +187,7 @@ impl Subscriptions {
                 res.ok().and_then(|val| {
                     val.as_str()
                         .map(str::to_owned)
-                        .or_else(|| val.as_u64().map(|uint: u64| format!("{}", uint)))
+                        .or_else(|| val.as_u64().map(|uint: u64| format!("{uint}")))
                 })
             })
             .collect::<Option<Vec<String>>>();

--- a/src/tabline.rs
+++ b/src/tabline.rs
@@ -30,7 +30,7 @@ impl State {
         let target = &self.data[idx as usize];
         if Some(target) != self.selected.as_ref() {
             if let Some(nvim) = self.nvim.as_ref().unwrap().nvim() {
-                nvim.block_timeout(nvim.set_current_tabpage(&target))
+                nvim.block_timeout(nvim.set_current_tabpage(target))
                     .report_err();
             }
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -357,7 +357,7 @@ impl Ui {
         shell: &shell::State,
         plug_manager: &UiMutex<plug_manager::Manager>,
         file_browser: &UiMutex<FileBrowserWidget>,
-        files_list: &Box<[String]>,
+        files_list: &[String],
         update_title: &SubscriptionHandle,
         update_subtitle: &Option<SubscriptionHandle>,
         update_completeopt: &SubscriptionHandle,

--- a/src/ui_model/item.rs
+++ b/src/ui_model/item.rs
@@ -64,7 +64,7 @@ impl Item {
     ) -> Option<gsk::TextNode> {
         gsk::TextNode::new(
             &self.font,
-            &mut self.glyphs().as_ref().unwrap().clone(),
+            &self.glyphs().as_ref().unwrap().clone(),
             &color.into(),
             &graphene::Point::new(x, y),
         )

--- a/src/ui_model/model_layout.rs
+++ b/src/ui_model/model_layout.rs
@@ -116,7 +116,7 @@ impl ModelLayout {
         let mut col_idx = 0;
         let mut row_idx = row_offset;
         for content in lines {
-            for &(ref hl, ref ch_list) in content {
+            for (hl, ch_list) in content {
                 for ch in ch_list {
                     let ch_width = max(1, ch.width());
 

--- a/src/ui_model/model_rect.rs
+++ b/src/ui_model/model_rect.rs
@@ -1,7 +1,7 @@
 use super::UiModel;
 use crate::render::CellMetrics;
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ModelRect {
     pub top: usize,
     pub bot: usize,

--- a/src/ui_model/model_rect.rs
+++ b/src/ui_model/model_rect.rs
@@ -67,10 +67,8 @@ impl ModelRect {
 
             let dw_char_idx = self.right + 1;
             if let Some(cell) = line.line.get(dw_char_idx) {
-                if cell.double_width {
-                    if right < dw_char_idx {
-                        right = dw_char_idx;
-                    }
+                if cell.double_width && right < dw_char_idx {
+                    right = dw_char_idx;
                 }
             }
         }


### PR DESCRIPTION
Using variables names directly in format strings might increase the minimum required Rust version and could be excluded from clippy lints.

Please let me know whether this is in scope for this repo. Clippy seems to do quite some readability improvements.