### PR TITLE
Load `ginit.vim` after saving `api_info` so rpc calls work

### DIFF
--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -454,10 +454,6 @@ pub async fn post_start_init(
     .await
     .map_err(NvimInitError::new_post_init)?;
 
-    nvim.timeout(nvim.command("runtime! ginit.vim"))
-        .await
-        .map_err(NvimInitError::new_post_init)?;
-
     if let Some(input_data) = input_data {
         let buf = nvim.timeout(nvim.get_current_buf()).await.ok_and_report();
 


### PR DESCRIPTION
This is the underlying cause to my issues in #49. Currently, `ginit.vim` is borderline useless, because the UI options that it sends to neovim are essentially dropped because we don't yet know that nvim supports the options.

The code for this isn't great, but I had a bit of trouble getting lifetimes to work and this was the best I was able to come up with. Edits welcome!