### PR TITLE
chore: fix clippy lint `type_complexity`

### DIFF
--- a/src/cmd_line/mod.rs
+++ b/src/cmd_line/mod.rs
@@ -129,13 +129,15 @@ impl Level {
     }
 }
 
+type PromptLine = (Rc<Highlight>, Vec<String>);
+
 fn prompt_lines(
     firstc: &str,
     prompt: &str,
     indent: u64,
     hl: &HighlightMap,
-) -> (usize, Vec<(Rc<Highlight>, Vec<String>)>) {
-    let prompt: Vec<(Rc<Highlight>, Vec<String>)> = if !firstc.is_empty() {
+) -> (usize, Vec<PromptLine>) {
+    let prompt: Vec<PromptLine> = if !firstc.is_empty() {
         if firstc.len() >= indent as usize {
             vec![(hl.default_hl(), vec![firstc.to_owned()])]
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![windows_subsystem = "windows"]
 #![allow(clippy::new_without_default)]
-#![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::comparison_chain)]
 #![allow(clippy::await_holding_refcell_ref)]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -183,6 +183,10 @@ impl ActionWidgets {
     }
 }
 
+type CommandCallback = Box<dyn FnMut(&mut State, nvim::NvimCommand) + Send + 'static>;
+type DetachedCallback = Box<RefCell<dyn FnMut() + Send + 'static>>;
+type NvimStartedCallback = Box<RefCell<dyn FnMut() + Send + 'static>>;
+
 pub struct State {
     pub grids: GridMap,
 
@@ -211,9 +215,9 @@ pub struct State {
     pub options: RefCell<ShellOptions>,
     transparency_settings: TransparencySettings,
 
-    detach_cb: Option<Box<RefCell<dyn FnMut() + Send + 'static>>>,
-    nvim_started_cb: Option<Box<RefCell<dyn FnMut() + Send + 'static>>>,
-    command_cb: Option<Box<dyn FnMut(&mut State, nvim::NvimCommand) + Send + 'static>>,
+    detach_cb: Option<DetachedCallback>,
+    nvim_started_cb: Option<NvimStartedCallback>,
+    command_cb: Option<CommandCallback>,
 
     subscriptions: RefCell<Subscriptions>,
 

--- a/src/ui_model/mod.rs
+++ b/src/ui_model/mod.rs
@@ -10,7 +10,7 @@ mod model_rect;
 pub use self::cell::Cell;
 pub use self::item::Item;
 pub use self::line::{Line, StyledLine};
-pub use self::model_layout::ModelLayout;
+pub use self::model_layout::{HighlightedLine, HighlightedRange, ModelLayout};
 pub use self::model_rect::ModelRect;
 
 #[derive(Default)]


### PR DESCRIPTION
Also use a proper type for often repeated `Vec<(Rc<Highlight>, Vec<String>)>`. I called it `HighlightedLine` consisting of multiple `HighlightedRanges`. The previous code referred to`Vec<(Rc<Highlight>, Vec<String>)>` often as `Content` if that's a better name.