### PR TITLE
Don't invert fallback cursor background highlight color

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -242,17 +242,15 @@ impl HighlightMap {
     }
 
     pub fn cursor_bg(&self) -> Cow<Color> {
-        let (main, fallback): (Option<&Color>, fn(&HighlightMap) -> Color) = if !self.cursor.reverse
-        {
-            (self.cursor.background.as_ref(), |hl_map| {
-                hl_map.bg().invert()
-            })
+        if self.cursor.reverse {
+            Cow::Borrowed(self.cursor.foreground.as_ref().unwrap_or_else(|| self.fg()))
         } else {
-            (self.cursor.foreground.as_ref(), |hl_map| *hl_map.fg())
-        };
-
-        main.map(Cow::Borrowed)
-            .unwrap_or_else(|| Cow::Owned(fallback(self)))
+            self.cursor
+                .background
+                .as_ref()
+                .map(Cow::Borrowed)
+                .unwrap_or_else(|| Cow::Owned(self.bg().invert()))
+        }
     }
 }
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -242,14 +242,17 @@ impl HighlightMap {
     }
 
     pub fn cursor_bg(&self) -> Cow<Color> {
-        let (main, fallback): (_, fn(_) -> _) = if !self.cursor.reverse {
-            (self.cursor.background.as_ref(), Self::bg)
+        let (main, fallback): (Option<&Color>, fn(&HighlightMap) -> Color) = if !self.cursor.reverse
+        {
+            (self.cursor.background.as_ref(), |hl_map| {
+                hl_map.bg().invert()
+            })
         } else {
-            (self.cursor.foreground.as_ref(), Self::fg)
+            (self.cursor.foreground.as_ref(), |hl_map| *hl_map.fg())
         };
 
         main.map(Cow::Borrowed)
-            .unwrap_or_else(|| Cow::Owned(fallback(self).invert()))
+            .unwrap_or_else(|| Cow::Owned(fallback(self)))
     }
 }
 


### PR DESCRIPTION
My current colorscheme doesn't set a `guifg` color for Cursor, and just relies on `gui=reverse` (and `cterm=reverse`). This is currently broken in nvim-gtk.

It's a bit hard to see since the cursor is not filled when taking a screenshot, but please use your imagination.

gnome-terminal:
![Screenshot from 2023-01-06 09-40-25](https://user-images.githubusercontent.com/3939997/211046609-9609280a-d66f-45e3-8523-37de77acbaed.png)


nvim-gtk:
![Screenshot from 2023-01-06 09-40-07](https://user-images.githubusercontent.com/3939997/211046618-c969bf67-d2de-435c-a822-d58ef0d4d07e.png)

Removing the `.invert()` call on the fallback color in `cursor_bg` seems to result in a color that I expect:
![Screenshot from 2023-01-06 09-42-21](https://user-images.githubusercontent.com/3939997/211046805-b34ef15c-8afe-4f14-b342-185f8aaf2987.png)


Am I missing something about why this `.invert()` call was here? Maybe it should only be called if `reverse` is false?