### PR TITLE
feat: allow to connect to Nvim via TCP

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,22 @@ impl ErrorArea {
         ));
         self.base.show();
     }
+
+    pub fn show_nvim_connect_error(&self, err: &str, addr: &str) {
+        error!("Can't connect to nvim on TCP address {}: {}\n", addr, err);
+        self.label.set_markup(&format!(
+            "<big>Can't connect to nvim instance on TCP address {}:</big>\n\
+             <i>{}</i>\n\
+             <big>Possible error reasons:</big>\n\
+             &#9679; Not supported nvim version (minimum supported version is <b>{}</b>)\n\
+             &#9679; Error in configuration file (init.vim or ginit.vim)\n\
+             &#9679; Invalid TCP address",
+            encode_text_minimal(addr),
+            encode_text_minimal(err),
+            shell::MINIMUM_SUPPORTED_NVIM_VERSION
+        ));
+        self.base.show();
+    }
 }
 
 impl Deref for ErrorArea {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ use log::error;
 use gio::prelude::*;
 use gio::ApplicationCommandLine;
 
+use std::net::SocketAddr;
 use std::{
     cell::RefCell,
     convert::*,
@@ -154,6 +155,10 @@ pub struct Args {
     #[arg(long)]
     /// Path to the nvim binary
     pub nvim_bin_path: Option<String>,
+
+    #[arg(long)]
+    /// Nvim server to connect to (currently TCP only)
+    pub server: Option<SocketAddr>,
 
     /// Arguments that will be passed to nvim (see more with '--help' before using!)
     ///


### PR DESCRIPTION
This allows to connect also to running nvim instances.

Externalized UI does of course not work and grid size also depends on the used terminal if unless started `--headless --embed`.

I also tried to create a connected via a ssh tunneled TCP, with the ssh connection established via openssh-rs (as opt-in feature), but didn't have success yet (or via ssh stdin/stdout). Probably that should be done by a user script. **EDIT**: I guess I fixed now it. I'll try another day.

TODO: 
- [ ] ~~support for unix pipes.~~ -> other PR 
- [x] give user feedback on invalid tcp addresses