### PR TITLE
Future clippy lints

### DIFF
--- a/src/shell_dlg.rs
+++ b/src/shell_dlg.rs
@@ -74,7 +74,7 @@ async fn show_not_saved_dlg(
         flags,
         MessageType::Question,
         ButtonsType::None,
-        &format!("Save changes to '{changed_files}'?"),
+        format!("Save changes to '{changed_files}'?"),
     );
 
     dlg.add_buttons(&[

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,5 +1,4 @@
 /// Tests for the command line interface (e.g. `nvim-gtk --no-fork foo.txt`)
-use trycmd;
 
 #[test]
 fn cli_tests() {


### PR DESCRIPTION
This PR tries to use a potential future clippy lint (I'm using nightly).

`String` implements `IntoGStr`. So the dereference is not necessary
here.

```
warning: the borrowed expression implements the required traits
  --> src/shell_dlg.rs:77:9
   |
77 |         &format!("Save changes to '{changed_files}'?"),
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `format!("Save changes to '{changed_files}'?")`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: `nvim-gtk` (bin "nvim-gtk") generated 1 warning (run `cargo clippy --fix --bin "nvim-gtk"` to apply 1 suggestion)
```

I also removed a unused import in one of the tests.
