### PR TITLE
Ignored `fg_index` / `bg_indexed` highlight attributes

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -323,6 +323,8 @@ impl Highlight {
                 "underdashed" => model_attrs.underdashed = true,
                 "strikethrough" => model_attrs.strikethrough = true,
                 "blend" => (),
+                // TODO: These two are not documented anywhere but used by the fzf plugin
+                "fg_indexed" | "bg_indexed" => (),
                 attr_key => error!("unknown attribute {attr_key}={val:?}"),
             };
         }


### PR DESCRIPTION
They're used by the fzf plugin but are not documented anywhere and it's not clear how to handled them.

Fixes https://github.com/Lyude/neovim-gtk/issues/86