### PR TITLE
Make `PopupMenu` "autohide"

### DIFF
--- a/src/popup_menu/mod.rs
+++ b/src/popup_menu/mod.rs
@@ -318,7 +318,7 @@ impl PopupMenu {
 
         let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
         let popover = PopupMenuPopover::new();
-        popover.set_autohide(false);
+        popover.set_autohide(true);
         popover.set_can_focus(false);
         popover.set_child(Some(&content));
         popover.add_css_class("background");


### PR DESCRIPTION
At the moment, neovim-gtk sets the "autohide" property of `PopoverMenu` to `false`. This will prevent automatic hiding of the popover from events that don't come from Neovim directly. E.g. clicking on the Nvim text area will clear the popover if `mouse=a` is set but not with `set mouse=` (the default for `mouse` is enabled `:h default-mouse`, value is `nvi`). Other UI events that would normally cause the popover to close like clicking on the tabline of Neovim-gtk or focusing another window or minimizing the neovim-gtk window, don't get handled at the moment. This is especially annoying when I switch to another window like my browser and the popover keeps hovering over webpages.

Setting `autohide` to `true` would give us a good default behavior for a GUI application at the cost possibly of deviating from the popover state of the embedded nvim instance. An alternative to setting `autohide` to `true` would be to handle certain events like focus loss of the window explicitly and then bringing it back when the focus returns. Please let me know which approach you would prefer!  

Btw. `set_autohide(false)` is also set for the cmd_line popover: https://github.com/theHamsta/neovim-gtk/blob/9417ddcbbc4d16da8de5cafce2c4d7e64c967a5e/src/cmd_line/mod.rs#L251

Fixes #100