### PR TITLE
Use a non-abstract accessible role

### DIFF
--- a/src/cmd_line/viewport.rs
+++ b/src/cmd_line/viewport.rs
@@ -55,7 +55,7 @@ impl ObjectSubclass for CmdlineViewportObject {
 
     fn class_init(klass: &mut Self::Class) {
         klass.set_css_name("widget");
-        klass.set_accessible_role(gtk::AccessibleRole::Widget);
+        klass.set_accessible_role(gtk::AccessibleRole::TextBox);
     }
 }
 

--- a/src/nvim_viewport.rs
+++ b/src/nvim_viewport.rs
@@ -70,7 +70,7 @@ impl ObjectSubclass for NvimViewportObject {
 
     fn class_init(klass: &mut Self::Class) {
         klass.set_css_name("widget");
-        klass.set_accessible_role(gtk::AccessibleRole::Widget);
+        klass.set_accessible_role(gtk::AccessibleRole::TextBox);
     }
 }
 


### PR DESCRIPTION
For our viewports, we use the Widget accessible role, which is abstract. That means that it is an overarching type representing multiple roles. It's not very helpful to a person with vision impairment to know that it's a general, generic widget, and because of that, GTK+ 4.12 warns about this:

    (NeovimGtk:584029): Gtk-CRITICAL **: 21:13:28.873: gtk_widget_class_set_accessible_role: assertion '!gtk_accessible_role_is_abstract (accessible_role)' failed

To help us create a more accessible user interface and to avoid annoying users by printing developer-specific errors to their terminal, let's pick a more specific, non-abstract role: TextBox.