### PR TITLE
highlight: ignore `url` attribute

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -325,6 +325,8 @@ impl Highlight {
                 "blend" => (),
                 // TODO: These two are not documented anywhere but used by the fzf plugin
                 "fg_indexed" | "bg_indexed" => (),
+                // TODO: This is used in Neovim 0.10 to indicate the target of a link.
+                "url" => (),
                 attr_key => error!("unknown attribute {attr_key}={val:?}"),
             };
         }


### PR DESCRIPTION
This attribute is used with Neovim 0.10 to indicate the target of a link.  As an example, it should be sufficient to run `:he treesitter`, at which point Neovim will emit it due to the URL.  There are, of course, various other help pages which trigger the issue.

We don't do anything with it now, which is fine, but not handling it in some way causes an error to be logged to the terminal, which is undesirable.  Ignore this attribute for now, and we can decide in the future if and how we want to handle it.