### PR TITLE
highlight: don't warn about nocombine attribute

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -323,6 +323,9 @@ impl Highlight {
                 "fg_indexed" | "bg_indexed" => (),
                 // TODO: This is used in Neovim 0.10 to indicate the target of a link.
                 "url" => (),
+                // TODO: This is used in Neovim 0.10 to indicate that attributes should be
+                // overridden instead of combined.
+                "nocombine" => (),
                 attr_key => error!("unknown attribute {attr_key}={val:?}"),
             };
         }


### PR DESCRIPTION
The nocombine attribute is more commonly used in Neovim 0.11 and newer, but exists in older versions as well.  Since we don't currently support it, simply do nothing for now to avoid printing messages to the terminal.

This is related to #98, but doesn't technically fix it (since it just silences the warning).