### PR TITLE
Easier system clipboard integration

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -983,6 +983,34 @@ impl Shell {
         ));
         state.nvim_viewport.add_controller(key_controller);
 
+        let clipboard_key_controller = gtk::EventControllerKey::new();
+        clipboard_key_controller.connect_key_pressed(glib::clone!(
+            #[weak]
+            state_ref,
+            #[upgrade_or]
+            glib::Propagation::Proceed,
+            move |_, key, _, modifiers| {
+                if modifiers != gdk::ModifierType::SHIFT_MASK | gdk::ModifierType::CONTROL_MASK {
+                    return glib::Propagation::Proceed;
+                }
+
+                match key {
+                    gdk::Key::C => {
+                        let state = state_ref.borrow();
+                        state.edit_copy("+");
+                        glib::Propagation::Stop
+                    }
+                    gdk::Key::V => {
+                        let state = state_ref.borrow();
+                        state.edit_paste("+");
+                        glib::Propagation::Stop
+                    }
+                    _ => glib::Propagation::Proceed,
+                }
+            }
+        ));
+        state.nvim_viewport.add_controller(clipboard_key_controller);
+
         fn get_button(controller: &gtk::GestureClick) -> u32 {
             match controller.current_button() {
                 0 => 1, // 0 == no button, e.g. it's a touch event, so map it to left click

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -618,7 +618,7 @@ impl State {
             if render_state.mode.is(&mode::NvimMode::Insert)
                 || render_state.mode.is(&mode::NvimMode::Normal)
             {
-                spawn_timeout_user_err!(nvim.command(&format!("normal! \"{clipboard}P")));
+                spawn_timeout_user_err!(nvim.command(&format!("normal! \"{clipboard}Pl")));
             } else {
                 spawn_timeout_user_err!(nvim.input(&format!("<C-r>{clipboard}")));
             };


### PR DESCRIPTION
This pull request contains two separate things:

 * Emulate pressing `l` (move to the right) after pasting while in insert mode.

This means pasting something from the system clipboard while insert mode doesn't end up with the cursor one character into the pasted string from the right. In effect, this means e.g. pasting 'abc' two times when in insert mode results in 'abcabc' instead of 'ababcc'.

I'm not sure emulating an `l` is the right way, but it works when I tested it.

* Grab Control+Shift+C and Control+Shift+V on a GTK level and handle them the same way as copy/pasting via the menu.

This means I can e.g. copy something from a web browser, regular text editor, etc, and then pasting it into the nvim buffer without having to click or typing command, without leaving the insert mode, using a rather common keybinding that I don't think you can normally bind using vim/nvim alone.

Perhaps it makes sense to make this one an option. If so, how do you suggest adding preferences? A gschema ala GTK apps, or is there some precedence how to configure neovim-gtk specifics using a .vim file or something like that?