### PR TITLE
Get rid of some unwraps for a None-existing nvim client

### DIFF
--- a/src/nvim/redraw_handler.rs
+++ b/src/nvim/redraw_handler.rs
@@ -231,7 +231,7 @@ pub fn call_gui_event(
         },
         "Option" => {
             let nvim_client = ui.nvim_clone();
-            let nvim = nvim_client.nvim().unwrap();
+            let nvim = nvim_client.nvim().ok_or("No nvim client")?;
             let api_info = nvim_client.api_info();
 
             let mut args = args.into_iter();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -643,9 +643,10 @@ impl State {
     }
 
     pub fn set_autocmds(&self) {
-        self.subscriptions
-            .borrow()
-            .set_autocmds(&self.nvim().unwrap());
+        let Some(nvim) = self.nvim() else {
+            return;
+        };
+        self.subscriptions.borrow().set_autocmds(&nvim);
     }
 
     pub fn notify(&self, params: Vec<Value>) -> Result<(), String> {
@@ -653,9 +654,10 @@ impl State {
     }
 
     pub fn run_now(&self, handle: &SubscriptionHandle) {
-        self.subscriptions
-            .borrow()
-            .run_now(handle, &self.nvim().unwrap());
+        let Some(nvim) = self.nvim() else {
+            return;
+        };
+        self.subscriptions.borrow().run_now(handle, &nvim);
     }
 
     pub fn set_font(&mut self, font_desc: String) {
@@ -1766,7 +1768,9 @@ impl State {
     pub fn grid_resize(&mut self, grid: u64, columns: u64, rows: u64) -> RedrawMode {
         debug!("on_resize {}/{}", columns, rows);
 
-        let nvim = self.nvim().unwrap();
+        let Some(nvim) = self.nvim() else {
+            return RedrawMode::Nothing;
+        };
         nvim.block_on(async {
             let mut resize_state = self.resize_status.requests.lock().await;
 

--- a/src/shell_dlg.rs
+++ b/src/shell_dlg.rs
@@ -85,19 +85,21 @@ async fn show_not_saved_dlg(
 
     let res = match dlg.run_future().await {
         gtk::ResponseType::Yes => {
-            let nvim = shell.borrow().state.borrow().nvim().unwrap();
-
-            // FIXME: Figure out a way to use timeouts with nvim interactions when using glib for
-            // async execution, either that or just don't use timeouts
-            match nvim.command("wa").await {
-                Err(err) => {
-                    match NormalError::try_from(&*err) {
-                        Ok(err) => err.print(&nvim).await,
-                        Err(_) => error!("Error: {}", err),
-                    };
-                    false
+            if let Some(nvim) = shell.borrow().state.borrow().nvim() {
+                // FIXME: Figure out a way to use timeouts with nvim interactions when using glib for
+                // async execution, either that or just don't use timeouts
+                match nvim.command("wa").await {
+                    Err(err) => {
+                        match NormalError::try_from(&*err) {
+                            Ok(err) => err.print(&nvim).await,
+                            Err(_) => error!("Error: {}", err),
+                        };
+                        false
+                    }
+                    _ => true,
                 }
-                _ => true,
+            } else {
+                false
             }
         }
         gtk::ResponseType::No => true,


### PR DESCRIPTION
These sometimes triggered during shutdown.