### PR TITLE
shell: Also emulate 'l' when pasting when in insert/normal mode

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -618,7 +618,7 @@ impl State {
             if render_state.mode.is(&mode::NvimMode::Insert)
                 || render_state.mode.is(&mode::NvimMode::Normal)
             {
-                spawn_timeout_user_err!(nvim.command(&format!("normal! \"{clipboard}P")));
+                spawn_timeout_user_err!(nvim.command(&format!("normal! \"{clipboard}Pl")));
             } else {
                 spawn_timeout_user_err!(nvim.input(&format!("<C-r>{clipboard}")));
             };


### PR DESCRIPTION
This makes it so that pressing the "paste" button when in insert mode results in the cursor moving to after the pasted string, meaning pasting multiple times results in the pasted string appearing multiple times, instead of being inserted before the last character in the previous pasted string.

Closes: https://github.com/Lyude/neovim-gtk/issues/82