### PR TITLE
Add Github Action Release builder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
         description: "Tag name for release"
         required: false
         default: nightly
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   linux:
@@ -92,16 +95,28 @@ jobs:
         run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
       - if: github.event_name == 'schedule'
         run: echo 'TAG_NAME=nightly' >> $GITHUB_ENV
+      - if: github.event_name == 'push'
+        run: |
+          TAG_NAME=${{ github.ref }}
+          echo "TAG_NAME=${TAG_NAME#refs/tags/}" >> $GITHUB_ENV
       - if: env.TAG_NAME == 'nightly'
         run: |
           (echo 'SUBJECT=Nvim GTK development (prerelease) build';
-           echo 'PRERELEASE=--prerelease') >> $GITHUB_ENV
+           echo 'PRERELEASE=--prerelease';
+           echo "RELEASE_TYPE=$TAG_NAME") >> $GITHUB_ENV
           gh release delete nightly --yes || true
           git push origin :nightly || true
+      - if: env.TAG_NAME != 'nightly'
+        run: |
+          (echo 'SUBJECT=Nvim GTK release build';
+           echo 'PRERELEASE=';
+           echo 'RELEASE_TYPE=stable') >> $GITHUB_ENV
+          gh release delete stable --yes || true
+          git push origin :stable || true
       - name: Publish release
         env:
           NVIM_GTK_VERSION: ${{ needs.linux.outputs.version }}
           NVIM_GTK_COMMIT: ${{ github.sha }}
           DEBUG: api
         run: |
-          gh release create $TAG_NAME $PRERELEASE --title "$SUBJECT" --target $GITHUB_SHA nvim-gtk-linux-x86_64/* nvim-gtk-linux-arm64/*
+          gh release create $RELEASE_TYPE $PRERELEASE --title "$SUBJECT" --target $GITHUB_SHA nvim-gtk-linux-x86_64/* nvim-gtk-linux-arm64/*


### PR DESCRIPTION
In order to achieve future CI builds, created this workflow for manually and nightly building and packaging distribute-able binaries.

This PR only approaches Linuxes' builds and sets placeholders for future MacOS and Windows ones.