### PR TITLE
Add command flags for environment variables

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,18 @@ pub struct Args {
     pub nvim_bin_path: Option<String>,
 
     #[arg(long)]
+    /// Hide header bar
+    pub no_header_bar: bool,
+
+    #[arg(long)]
+    /// Disable window decoration
+    pub no_window_decoration: bool,
+
+    #[arg(long)]
+    /// Allow to use the dark theme variant
+    pub prefer_dark_theme: bool,
+
+    #[arg(long)]
     #[cfg_attr(unix, doc = "Nvim server to connect to (TCP address or Unix socket)")]
     #[cfg_attr(not(unix), doc = "Nvim server to connect to (TCP only)")]
     pub server: Option<NvimTransport>,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -149,7 +149,8 @@ impl Ui {
 
             let prefer_dark_theme = env::var("NVIM_GTK_PREFER_DARK_THEME")
                 .map(|opt| opt.trim() == "1")
-                .unwrap_or(false);
+                .unwrap_or(false)
+                || args.prefer_dark_theme;
             if prefer_dark_theme {
                 window
                     .settings()
@@ -178,11 +179,13 @@ impl Ui {
         // Client side decorations including the toolbar are disabled via NVIM_GTK_NO_HEADERBAR=1
         let use_header_bar = env::var("NVIM_GTK_NO_HEADERBAR")
             .map(|opt| opt.trim() != "1")
-            .unwrap_or(true);
+            .unwrap_or(true)
+            && !args.no_header_bar;
 
         let disable_window_decoration = env::var("NVIM_GTK_NO_WINDOW_DECORATION")
             .map(|opt| opt.trim() == "1")
-            .unwrap_or(false);
+            .unwrap_or(false)
+            && !args.no_window_decoration;
 
         if disable_window_decoration {
             window.set_decorated(false);


### PR DESCRIPTION
Add three command line flags:

- `--no-header-bar`
- `--no-window-decoration`
- `--prefer-dark-theme`

This makes the documentation easier, as command line flags are automatically documented through `--help`.
This also makes the software usage more consistent, as there is already a flag for `--hide-sidebar`.
