### PR TITLE
Apply small hot-path cleanups

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -48,12 +48,7 @@ impl GridMap {
     }
 
     pub fn get_or_create(&mut self, idx: u64) -> &mut Grid {
-        if self.grids.contains_key(&idx) {
-            return self.grids.get_mut(&idx).unwrap();
-        }
-
-        self.grids.insert(idx, Grid::new());
-        self.grids.get_mut(&idx).unwrap()
+        self.grids.entry(idx).or_insert_with(Grid::new)
     }
 
     pub fn destroy(&mut self, idx: u64) {
@@ -160,5 +155,19 @@ impl Grid {
             rows,
             default_hl,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_or_create_reuses_existing_grid() {
+        let mut grids = GridMap::new();
+
+        grids.get_or_create(7).cursor_goto(3, 4);
+
+        assert_eq!((3, 4), grids.get_or_create(7).get_cursor());
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -555,9 +555,8 @@ fn snapshot_cell(
     cell_metrics: &CellMetrics,
 ) {
     let (x, y) = cell_metrics.get_pixel_coords(pos);
+    let fg = hl.actual_cell_fg(cell);
     for item in items {
-        let fg = hl.actual_cell_fg(cell);
-
         if item.glyphs().is_some()
             && let Some(render_node) =
                 item.render_node(fg, (x as f32, (y + cell_metrics.ascent) as f32))


### PR DESCRIPTION
A couple of low-cost hot-path cleanups were still available in the grid and rendering code. GridMap::get_or_create() performed two hash lookups before insertion, and snapshot_cell() recomputed the same foreground color for every item in the cell.

Tighten those paths up instead:
- use HashMap::entry().or_insert_with(...) for grid creation
- compute the cell foreground color once before iterating over grouped items
- add a unit test covering grid reuse through get_or_create()