### PR TITLE
Coalesce redraw notifications before entering GTK

### DIFF
--- a/src/nvim/handler.rs
+++ b/src/nvim/handler.rs
@@ -1,6 +1,6 @@
 use std::{
-    result,
-    sync::{Arc, mpsc},
+    mem, result,
+    sync::{Arc, Mutex, mpsc},
 };
 
 use log::{debug, error};
@@ -18,6 +18,7 @@ use super::redraw_handler::{self, PendingPopupMenu, RedrawMode};
 pub struct NvimHandler {
     shell: Arc<UiMutex<shell::State>>,
     resize_status: Arc<shell::ResizeState>,
+    pending_redraws: Arc<Mutex<PendingRedraws>>,
 }
 
 impl NvimHandler {
@@ -25,12 +26,13 @@ impl NvimHandler {
         NvimHandler {
             shell,
             resize_status,
+            pending_redraws: Arc::new(Mutex::new(PendingRedraws::default())),
         }
     }
 
     async fn nvim_cb(&self, method: String, params: Vec<Value>) {
         match method.as_ref() {
-            "redraw" => self.safe_call(move |ui| call_redraw_handler(params, ui)),
+            "redraw" => self.queue_redraw(params),
             "Gui" => {
                 if !params.is_empty() {
                     let mut params_iter = params.into_iter();
@@ -123,16 +125,99 @@ impl NvimHandler {
     {
         safe_call(self.shell.clone(), cb);
     }
+
+    fn queue_redraw(&self, params: Vec<Value>) {
+        queue_redraw(self.shell.clone(), self.pending_redraws.clone(), params);
+    }
 }
 
-fn call_redraw_handler(
+#[derive(Default)]
+struct PendingRedraws {
+    scheduled: bool,
+    batches: Vec<Vec<Value>>,
+}
+
+impl PendingRedraws {
+    fn enqueue(&mut self, params: Vec<Value>) -> bool {
+        self.batches.push(params);
+        if self.scheduled {
+            false
+        } else {
+            self.scheduled = true;
+            true
+        }
+    }
+
+    fn take_pending(&mut self) -> Option<Vec<Vec<Value>>> {
+        if self.batches.is_empty() {
+            self.scheduled = false;
+            None
+        } else {
+            Some(mem::take(&mut self.batches))
+        }
+    }
+}
+
+fn queue_redraw(
+    shell: Arc<UiMutex<shell::State>>,
+    pending_redraws: Arc<Mutex<PendingRedraws>>,
     params: Vec<Value>,
+) {
+    let should_schedule = {
+        let mut pending_redraws = pending_redraws.lock().unwrap();
+        pending_redraws.enqueue(params)
+    };
+
+    if !should_schedule {
+        return;
+    }
+
+    // Neovim may emit many small redraw notifications in a burst. Drain as many pending batches as
+    // possible in one GTK idle cycle so we avoid scheduling redundant redraw callbacks.
+    glib::idle_add_once(move || {
+        loop {
+            let pending_batches = {
+                let mut pending_redraws = pending_redraws.lock().unwrap();
+                pending_redraws.take_pending()
+            };
+
+            let Some(pending_batches) = pending_batches else {
+                break;
+            };
+
+            if let Err(msg) = call_redraw_handlers(pending_batches, &shell) {
+                error!("Error call function: {msg}");
+            }
+        }
+    });
+}
+
+fn call_redraw_handlers(
+    pending_batches: Vec<Vec<Value>>,
     ui: &Arc<UiMutex<shell::State>>,
 ) -> result::Result<(), String> {
     let mut repaint_mode = RedrawMode::Nothing;
     let mut pending_popupmenu = PendingPopupMenu::None;
 
     let mut ui_ref = ui.borrow_mut();
+    for params in pending_batches {
+        let (call_repaint_mode, call_popupmenu) = process_redraw_batch(params, &mut ui_ref)?;
+        repaint_mode = repaint_mode.max(call_repaint_mode);
+        pending_popupmenu.update(call_popupmenu);
+    }
+    ui_ref.queue_draw(repaint_mode);
+    drop(ui_ref);
+    ui.borrow().popupmenu_flush(pending_popupmenu);
+    Ok(())
+}
+
+fn process_redraw_batch(
+    params: Vec<Value>,
+    ui_ref: &mut shell::State,
+) -> result::Result<(RedrawMode, PendingPopupMenu), String> {
+    let mut repaint_mode = RedrawMode::Nothing;
+    let mut pending_popupmenu = PendingPopupMenu::None;
+
     for ev in params {
         let ev_args = match ev {
             Value::Array(args) => args,
@@ -171,7 +256,7 @@ fn call_redraw_handler(
             };
 
             let (call_repaint_mode, call_popupmenu) =
-                match redraw_handler::call(&mut ui_ref, ev_name, args) {
+                match redraw_handler::call(ui_ref, ev_name, args) {
                     Ok(mode) => mode,
                     Err(desc) => return Err(format!("Event {ev_name}\n{desc}")),
                 };
@@ -180,10 +265,7 @@ fn call_redraw_handler(
         }
     }
 
-    ui_ref.queue_draw(repaint_mode);
-    drop(ui_ref);
-    ui.borrow().popupmenu_flush(pending_popupmenu);
-    Ok(())
+    Ok((repaint_mode, pending_popupmenu))
 }
 
 fn safe_call<F>(shell: Arc<UiMutex<shell::State>>, cb: F)
@@ -202,6 +284,7 @@ impl Clone for NvimHandler {
         NvimHandler {
             shell: self.shell.clone(),
             resize_status: self.resize_status.clone(),
+            pending_redraws: self.pending_redraws.clone(),
         }
     }
 }
@@ -221,5 +304,27 @@ impl Handler for NvimHandler {
         _: Neovim,
     ) -> result::Result<Value, Value> {
         self.nvim_cb_req(name, args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_redraws_only_schedule_one_idle_until_fully_drained() {
+        let mut pending = PendingRedraws::default();
+
+        assert!(pending.enqueue(vec![Value::Nil]));
+        assert!(!pending.enqueue(vec![Value::Nil]));
+        assert_eq!(2, pending.take_pending().unwrap().len());
+
+        // The existing idle callback remains responsible for newly queued redraws until it observes
+        // the queue empty again.
+        assert!(!pending.enqueue(vec![Value::Nil]));
+        assert_eq!(1, pending.take_pending().unwrap().len());
+
+        assert!(pending.take_pending().is_none());
+        assert!(pending.enqueue(vec![Value::Nil]));
     }
 }

--- a/src/nvim/handler.rs
+++ b/src/nvim/handler.rs
@@ -149,8 +149,8 @@ impl PendingRedraws {
     }
 
     fn take_pending(&mut self) -> Option<Vec<Vec<Value>>> {
+        self.scheduled = false;
         if self.batches.is_empty() {
-            self.scheduled = false;
             None
         } else {
             Some(mem::take(&mut self.batches))
@@ -172,22 +172,21 @@ fn queue_redraw(
         return;
     }
 
-    // Neovim may emit many small redraw notifications in a burst. Drain as many pending batches as
-    // possible in one GTK idle cycle so we avoid scheduling redundant redraw callbacks.
+    // Process one coalesced batch per GTK idle callback. If more redraws arrive while this batch
+    // is being handled, enqueue() will schedule the next idle callback after take_pending()
+    // clears the current scheduled flag.
     glib::idle_add_once(move || {
-        loop {
-            let pending_batches = {
-                let mut pending_redraws = pending_redraws.lock().unwrap();
-                pending_redraws.take_pending()
-            };
+        let pending_batches = {
+            let mut pending_redraws = pending_redraws.lock().unwrap();
+            pending_redraws.take_pending()
+        };
 
-            let Some(pending_batches) = pending_batches else {
-                break;
-            };
+        let Some(pending_batches) = pending_batches else {
+            return;
+        };
 
-            if let Err(msg) = call_redraw_handlers(pending_batches, &shell) {
-                error!("Error call function: {msg}");
-            }
+        if let Err(msg) = call_redraw_handlers(pending_batches, &shell) {
+            error!("Error call function: {msg}");
         }
     });
 }
@@ -312,17 +311,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pending_redraws_only_schedule_one_idle_until_fully_drained() {
+    fn pending_redraws_reschedule_after_current_batch_is_taken() {
         let mut pending = PendingRedraws::default();
 
         assert!(pending.enqueue(vec![Value::Nil]));
         assert!(!pending.enqueue(vec![Value::Nil]));
         assert_eq!(2, pending.take_pending().unwrap().len());
 
-        // The existing idle callback remains responsible for newly queued redraws until it observes
-        // the queue empty again.
+        // Once the current idle callback has taken ownership of the pending redraws, newly queued
+        // redraws must schedule the next idle callback.
+        assert!(pending.enqueue(vec![Value::Nil]));
         assert!(!pending.enqueue(vec![Value::Nil]));
-        assert_eq!(1, pending.take_pending().unwrap().len());
+        assert_eq!(2, pending.take_pending().unwrap().len());
 
         assert!(pending.take_pending().is_none());
         assert!(pending.enqueue(vec![Value::Nil]));


### PR DESCRIPTION
Neovim can emit many small redraw notifications in a burst. The old handler scheduled one glib::idle_add_once callback per notification, which left the GTK main loop processing a long queue of tiny redraw callbacks and often calling queue_draw() repeatedly for work that could have been handled in the same idle cycle.

Coalesce redraw work in NvimHandler instead:
- queue redraw notifications in a shared pending list
- keep at most one GTK idle callback scheduled at a time
- drain all pending redraw batches in a single idle cycle
- combine redraw mode and popup menu updates before queue_draw()
- add a unit test covering the pending redraw queue semantics