### PR TITLE
Add incremental line snapshot caching

### DIFF
--- a/src/nvim_viewport.rs
+++ b/src/nvim_viewport.rs
@@ -12,6 +12,7 @@ use crate::{
     render::*,
     shell::{RenderState, State},
     ui::UiMutex,
+    ui_model,
 };
 
 glib::wrapper! {
@@ -44,6 +45,34 @@ impl NvimViewport {
     pub fn clear_snapshot_cache(&self) {
         self.set_property("snapshot-cached", false);
     }
+
+    pub fn invalidate_snapshot_lines(&self, ui_model: &ui_model::UiModel) {
+        self.imp()
+            .inner
+            .borrow_mut()
+            .invalidate_snapshot_lines(ui_model);
+    }
+}
+
+struct CachedLineSnapshot {
+    snapshot: Option<gsk::RenderNode>,
+    dirty: bool,
+}
+
+impl CachedLineSnapshot {
+    fn invalidate(&mut self) {
+        self.snapshot = None;
+        self.dirty = true;
+    }
+}
+
+impl Default for CachedLineSnapshot {
+    fn default() -> Self {
+        Self {
+            snapshot: None,
+            dirty: true,
+        }
+    }
 }
 
 /** The inner state structure for the viewport widget, for holding non-glib types (e.g. ones that
@@ -51,7 +80,45 @@ impl NvimViewport {
 #[derive(Default)]
 struct NvimViewportInner {
     state: Weak<UiMutex<State>>,
-    snapshot_cache: Option<gsk::RenderNode>,
+    snapshot_cache: Vec<CachedLineSnapshot>,
+    snapshot_dimensions: Option<(usize, usize)>,
+}
+
+impl NvimViewportInner {
+    fn clear_snapshot_cache(&mut self) {
+        self.snapshot_cache.clear();
+        self.snapshot_dimensions = None;
+    }
+
+    fn has_cached_snapshot(&self) -> bool {
+        self.snapshot_cache.iter().any(|line| !line.dirty)
+    }
+
+    fn ensure_snapshot_cache(&mut self, rows: usize, columns: usize) {
+        if self.snapshot_dimensions == Some((rows, columns)) {
+            return;
+        }
+
+        self.snapshot_cache = std::iter::repeat_with(CachedLineSnapshot::default)
+            .take(rows)
+            .collect();
+        self.snapshot_dimensions = Some((rows, columns));
+    }
+
+    fn invalidate_snapshot_lines(&mut self, ui_model: &ui_model::UiModel) {
+        if self.snapshot_dimensions != Some((ui_model.rows, ui_model.columns)) {
+            self.clear_snapshot_cache();
+            return;
+        }
+
+        for (row, line) in ui_model.model().iter().enumerate() {
+            if line.dirty_line
+                && let Some(cached_line) = self.snapshot_cache.get_mut(row)
+            {
+                cached_line.invalidate();
+            }
+        }
+    }
 }
 
 #[derive(Default)]
@@ -115,7 +182,7 @@ impl ObjectImpl for NvimViewportObject {
             }
             "snapshot-cached" => {
                 if !value.get::<bool>().unwrap() {
-                    self.inner.borrow_mut().snapshot_cache = None;
+                    self.inner.borrow_mut().clear_snapshot_cache();
                 }
             }
             "context-menu" => {
@@ -153,7 +220,7 @@ impl ObjectImpl for NvimViewportObject {
 
     fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
         match pspec.name() {
-            "snapshot-cached" => self.inner.borrow().snapshot_cache.is_some().to_value(),
+            "snapshot-cached" => self.inner.borrow().has_cached_snapshot().to_value(),
             "context-menu" => self.context_menu.upgrade().to_value(),
             "completion-popover" => self.completion_popover.upgrade().to_value(),
             "ext-cmdline" => self.ext_cmdline.upgrade().to_value(),
@@ -200,27 +267,43 @@ impl WidgetImpl for NvimViewportObject {
         );
 
         if state.nvim_clone().is_initialized() {
-            // Render scenes get pretty huge here, so we cache them as often as possible
+            // Render scenes get pretty huge here, so we cache them per line and only rebuild the
+            // lines touched by the last redraw.
             let font_ctx = &render_state.font_ctx;
-            if inner.snapshot_cache.is_none() {
-                let ui_model = match state.grids.current_model() {
-                    Some(ui_model) => ui_model,
-                    None => return,
+            let ui_model = match state.grids.current_model() {
+                Some(ui_model) => ui_model,
+                None => return,
+            };
+
+            // Recreate the full cache only when the grid dimensions change. Otherwise we keep the
+            // previous render nodes and rebuild only dirty lines below.
+            inner.ensure_snapshot_cache(ui_model.rows, ui_model.columns);
+            debug_assert_eq!(ui_model.model().len(), inner.snapshot_cache.len());
+            let push_opacity = transparency.filled_alpha < 0.99999;
+            if push_opacity {
+                snapshot_in.push_opacity(transparency.filled_alpha)
+            }
+
+            for (row, (line, cached_line)) in ui_model
+                .model()
+                .iter()
+                .zip(inner.snapshot_cache.iter_mut())
+                .enumerate()
+            {
+                if cached_line.dirty {
+                    cached_line.snapshot = snapshot_nvim_line(font_ctx, line, row, hl);
+                    cached_line.dirty = false;
+                }
+
+                let Some(cached_snapshot) = cached_line.snapshot.as_ref() else {
+                    continue;
                 };
 
-                inner.snapshot_cache = snapshot_nvim(font_ctx, ui_model, hl);
-            }
-            if let Some(ref cached_snapshot) = inner.snapshot_cache {
-                let push_opacity = transparency.filled_alpha < 0.99999;
-                if push_opacity {
-                    snapshot_in.push_opacity(transparency.filled_alpha)
-                }
-
                 snapshot_in.append_node(cached_snapshot);
+            }
 
-                if push_opacity {
-                    snapshot_in.pop();
-                }
+            if push_opacity {
+                snapshot_in.pop();
             }
 
             if let Some(cursor) = state.cursor()
@@ -250,5 +333,49 @@ impl NvimViewportObject {
             obj.allocated_height() as f64 / 2.0 - height as f64 / 2.0,
             &layout,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clean_snapshot_cache(inner: &mut NvimViewportInner) {
+        for line in &mut inner.snapshot_cache {
+            line.dirty = false;
+        }
+    }
+
+    #[test]
+    fn invalidate_snapshot_lines_only_marks_dirty_rows() {
+        let mut inner = NvimViewportInner::default();
+        inner.ensure_snapshot_cache(3, 4);
+        clean_snapshot_cache(&mut inner);
+
+        let mut model = ui_model::UiModel::new(3, 4);
+        for line in model.model_mut().iter_mut() {
+            line.dirty_line = false;
+        }
+        model.model_mut()[1].dirty_line = true;
+
+        inner.invalidate_snapshot_lines(&model);
+
+        assert!(!inner.snapshot_cache[0].dirty);
+        assert!(inner.snapshot_cache[1].dirty);
+        assert!(!inner.snapshot_cache[2].dirty);
+        assert_eq!(inner.snapshot_dimensions, Some((3, 4)));
+    }
+
+    #[test]
+    fn invalidate_snapshot_lines_clears_cache_on_dimension_change() {
+        let mut inner = NvimViewportInner::default();
+        inner.ensure_snapshot_cache(3, 4);
+        clean_snapshot_cache(&mut inner);
+
+        let model = ui_model::UiModel::new(4, 4);
+        inner.invalidate_snapshot_lines(&model);
+
+        assert!(inner.snapshot_cache.is_empty());
+        assert_eq!(inner.snapshot_dimensions, None);
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -80,83 +80,83 @@ enum RenderStepKind {
     Strikethrough,
 }
 
+pub fn snapshot_nvim_line(
+    font_ctx: &Context,
+    line: &ui_model::Line,
+    row: usize,
+    hl: &HighlightMap,
+) -> Option<gsk::RenderNode> {
+    let snapshot = gtk::Snapshot::new();
+    let cell_metrics = font_ctx.cell_metrics();
+    let columns = line.line.len();
+
+    // Various operations for text formatting come at the end, so store them in a list until then.
+    // We set the capacity to three times the size of the row, since at most each cell can have
+    // strikethrough + a type of underline + the second line in an underdouble.
+    let mut text_fmt_steps = Vec::with_capacity(columns * 3);
+
+    let mut pending_bg = None;
+    let mut pending_strikethrough = None;
+    let mut pending_underline = None;
+    let mut pending_underdouble = None;
+
+    for (col, cell) in line.line.iter().enumerate() {
+        // Plan each step of the process of creating this snapshot as much as possible. We use
+        // the term "plan" to describe the process of generating as few snapshot nodes as possible
+        // in order to accomplish each step in creating a snapshot for the final image.
+        plan_and_snapshot_cell_bg(
+            &snapshot,
+            &mut pending_bg,
+            hl,
+            cell,
+            cell_metrics,
+            (row, col),
+        );
+        plan_underline_strikethrough(
+            &mut pending_strikethrough,
+            &mut pending_underline,
+            &mut pending_underdouble,
+            &mut text_fmt_steps,
+            hl,
+            cell,
+            (row, col),
+        );
+    }
+
+    if let Some(pending_bg) = pending_bg {
+        pending_bg.to_snapshot(&snapshot, cell_metrics);
+    }
+
+    for (col, cell) in line.line.iter().enumerate() {
+        snapshot_cell(
+            &snapshot,
+            &line.item_line[col],
+            hl,
+            cell,
+            (row, col),
+            cell_metrics,
+        );
+    }
+
+    for step in text_fmt_steps.into_iter() {
+        step.to_snapshot(&snapshot, cell_metrics);
+    }
+
+    snapshot.to_node()
+}
+
 pub fn snapshot_nvim(
     font_ctx: &Context,
     ui_model: &ui_model::UiModel,
     hl: &HighlightMap,
 ) -> Option<gsk::RenderNode> {
+    // Some code paths, such as the cmdline viewport, still consume a full-grid snapshot.
     let snapshot = gtk::Snapshot::new();
-    let cell_metrics = font_ctx.cell_metrics();
-    let (rows, columns) = (ui_model.rows, ui_model.columns);
 
-    // Various operations for text formatting come at the end, so store them in a list until then.
-    // We set the capacity to three times the size of the grid, since at most each cell can have
-    // strikethrough + a type of underline + the second line in an underdouble. Most of the time
-    // though, we optimistically expect this list to be much smaller than iterating through the UI
-    // model.
-    let mut text_fmt_steps = Vec::with_capacity(columns * rows * 3);
-
-    // Note that we group each batch of nodes based on their type, since GTK+ does a better job of
-    // optimizing contiguous series of similar drawing operations (source: Company)
-    let model = ui_model.model();
-    for (row, line) in model.iter().enumerate() {
-        let mut pending_bg = None;
-        let mut pending_strikethrough = None;
-        let mut pending_underline = None;
-        let mut pending_underdouble = None;
-
-        for (col, cell) in line.line.iter().enumerate() {
-            // Plan each step of the process of creating this snapshot as much as possible. We use
-            // the term "plan" to describe the process of generating as few snapshot nodes as
-            // possible in order to accomplish each step in creating a snapshot for the final image.
-            // For example, if multiple adjacent background nodes have identical background colors -
-            // our planning phase will generate a single snapshot node for any contiguous group of
-            // cells. Where possible, we immediately generate nodes and add them to the snapshot.
-            //
-            // Currently, the only step of the rendering process we don't do this for is with
-            // text nodes - where we rely on the itemization process to have already done this for
-            // us. Additionally, all optimizations are limited to each row. We do not for instance,
-            // combine the background nodes of multiple identical adjacent rows.
-            plan_and_snapshot_cell_bg(
-                &snapshot,
-                &mut pending_bg,
-                hl,
-                cell,
-                cell_metrics,
-                (row, col),
-            );
-            plan_underline_strikethrough(
-                &mut pending_strikethrough,
-                &mut pending_underline,
-                &mut pending_underdouble,
-                &mut text_fmt_steps,
-                hl,
-                cell,
-                (row, col),
-            );
+    for (row, line) in ui_model.model().iter().enumerate() {
+        if let Some(line_snapshot) = snapshot_nvim_line(font_ctx, line, row, hl) {
+            snapshot.append_node(&line_snapshot);
         }
-
-        // Since background nodes come first, we can add them to the snapshot immediately
-        if let Some(pending_bg) = pending_bg {
-            pending_bg.to_snapshot(&snapshot, cell_metrics);
-        }
-    }
-
-    for (row, line) in model.iter().enumerate() {
-        for (col, cell) in line.line.iter().enumerate() {
-            snapshot_cell(
-                &snapshot,
-                &line.item_line[col],
-                hl,
-                cell,
-                (row, col),
-                cell_metrics,
-            );
-        }
-    }
-
-    for step in text_fmt_steps.into_iter() {
-        step.to_snapshot(&snapshot, cell_metrics);
     }
 
     snapshot.to_node()

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1758,10 +1758,14 @@ impl State {
             return;
         }
 
-        if mode >= RedrawMode::ClearCache {
-            if mode == RedrawMode::All {
-                self.update_dirty_glyphs();
+        if mode == RedrawMode::All {
+            if let Some(model) = self.grids.current_model() {
+                self.nvim_viewport.invalidate_snapshot_lines(model);
+            } else {
+                self.nvim_viewport.clear_snapshot_cache();
             }
+            self.update_dirty_glyphs();
+        } else if mode >= RedrawMode::ClearCache {
             self.nvim_viewport.clear_snapshot_cache();
         }
 


### PR DESCRIPTION
Cache viewport snapshots per line instead of rebuilding the whole grid on every text redraw.

Invalidate only dirty lines before reshaping glyphs and keep the full-grid snapshot helper for the command-line view.