### PR TITLE
Reuse item and glyph allocations in the shaping hot path

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -127,15 +127,18 @@ pub fn snapshot_nvim_line(
         pending_bg.to_snapshot(&snapshot, cell_metrics);
     }
 
-    for (col, cell) in line.line.iter().enumerate() {
+    let mut col = 0;
+    while col < line.line.len() {
+        let cell = &line.line[col];
         snapshot_cell(
             &snapshot,
-            &line.item_line[col],
+            line.get_items(col),
             hl,
             cell,
             (row, col),
             cell_metrics,
         );
+        col += line.item_len_from_idx(col);
     }
 
     for step in text_fmt_steps.into_iter() {
@@ -554,6 +557,10 @@ fn snapshot_cell(
     pos: (usize, usize),
     cell_metrics: &CellMetrics,
 ) {
+    if items.is_empty() {
+        return;
+    }
+
     let (x, y) = cell_metrics.get_pixel_coords(pos);
     let fg = hl.actual_cell_fg(cell);
     for item in items {
@@ -579,19 +586,14 @@ pub fn shape_dirty(ctx: &context::Context, ui_model: &mut ui_model::UiModel, hl:
         for (col, cell) in line.line.iter_mut().enumerate() {
             if cell.dirty {
                 for item in &mut *line.item_line[col] {
-                    let mut glyphs = pango::GlyphString::new();
-                    {
-                        let analysis = item.analysis();
-                        let offset = item.item.offset() as usize;
-                        let length = item.item.length() as usize;
-                        if let Some(line_str) = styled_line.line_str.get(offset..offset + length) {
-                            pango::shape(line_str, analysis, &mut glyphs);
-                        } else {
-                            warn!("Wrong itemize split");
-                        }
+                    let offset = item.item.offset() as usize;
+                    let length = item.item.length() as usize;
+                    if let Some(line_str) = styled_line.line_str.get(offset..offset + length) {
+                        item.shape(line_str);
+                    } else {
+                        item.clear_glyphs();
+                        warn!("Wrong itemize split");
                     }
-
-                    item.set_glyphs(glyphs);
                 }
             }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -127,15 +127,18 @@ pub fn snapshot_nvim_line(
         pending_bg.to_snapshot(&snapshot, cell_metrics);
     }
 
-    for (col, cell) in line.line.iter().enumerate() {
+    let mut col = 0;
+    while col < line.line.len() {
+        let cell = &line.line[col];
         snapshot_cell(
             &snapshot,
-            &line.item_line[col],
+            line.get_items(col),
             hl,
             cell,
             (row, col),
             cell_metrics,
         );
+        col += line.item_len_from_idx(col);
     }
 
     for step in text_fmt_steps.into_iter() {
@@ -554,6 +557,10 @@ fn snapshot_cell(
     pos: (usize, usize),
     cell_metrics: &CellMetrics,
 ) {
+    if items.is_empty() {
+        return;
+    }
+
     let (x, y) = cell_metrics.get_pixel_coords(pos);
     let fg = hl.actual_cell_fg(cell);
     for item in items {
@@ -585,19 +592,14 @@ pub fn shape_dirty(ctx: &context::Context, ui_model: &mut ui_model::UiModel, hl:
             let cell = &mut line.line[col];
             if cell.dirty {
                 for item in &mut *line.item_line[col] {
-                    let mut glyphs = pango::GlyphString::new();
-                    {
-                        let analysis = item.analysis();
-                        let offset = item.item.offset() as usize;
-                        let length = item.item.length() as usize;
-                        if let Some(line_str) = styled_line.line_str.get(offset..offset + length) {
-                            pango::shape(line_str, analysis, &mut glyphs);
-                        } else {
-                            warn!("Wrong itemize split");
-                        }
+                    let offset = item.item.offset() as usize;
+                    let length = item.item.length() as usize;
+                    if let Some(line_str) = styled_line.line_str.get(offset..offset + length) {
+                        item.shape(line_str);
+                    } else {
+                        item.clear_glyphs();
+                        warn!("Wrong itemize split");
                     }
-
-                    item.set_glyphs(glyphs);
                 }
             }
 

--- a/src/ui_model/item.rs
+++ b/src/ui_model/item.rs
@@ -41,6 +41,30 @@ impl Item {
         *self.render_node.borrow_mut() = None;
     }
 
+    pub fn update(&mut self, item: pango::Item, cells_count: usize) {
+        debug_assert!(cells_count > 0);
+
+        self.font = item.analysis().font();
+        self.item = item;
+        self.cells_count = cells_count;
+        *self.render_node.get_mut() = None;
+    }
+
+    pub fn clear_glyphs(&mut self) {
+        *self.glyphs.get_mut() = None;
+        *self.render_node.get_mut() = None;
+    }
+
+    pub fn shape(&mut self, text: &str) {
+        let analysis = self.item.analysis();
+        let glyphs = self
+            .glyphs
+            .get_mut()
+            .get_or_insert_with(pango::GlyphString::new);
+        pango::shape(text, analysis, glyphs);
+        *self.render_node.get_mut() = None;
+    }
+
     pub fn render_node(&self, color: &color::Color, (x, y): (f32, f32)) -> Option<gsk::TextNode> {
         let mut render_node = self.render_node.borrow_mut();
         if let Some(ref render_node) = *render_node {

--- a/src/ui_model/line.rs
+++ b/src/ui_model/line.rs
@@ -131,13 +131,7 @@ impl Line {
                 .iter()
                 .any(|c| c.dirty)
             {
-                self.item_line[new_item.start_cell] = new_item
-                    .items
-                    .iter()
-                    .map(|i| Item::new((*i).clone(), cell_count as usize))
-                    .collect();
-                self.line[new_item.start_cell].dirty = true;
-                true
+                self.update_cell_item(new_item)
             } else {
                 false
             }
@@ -182,13 +176,34 @@ impl Line {
             self.line[i].dirty = true;
             self.cell_to_item[i] = new_item.start_cell as i32;
         }
-        self.item_line[new_item.start_cell + 1..=new_item.end_cell].fill(Box::default());
+        if new_item.start_cell < new_item.end_cell {
+            self.item_line[new_item.start_cell + 1..=new_item.end_cell].fill(Box::default());
+        }
         let cells_count = new_item.end_cell - new_item.start_cell + 1;
-        self.item_line[new_item.start_cell] = new_item
+        self.item_line[new_item.start_cell] = Self::collect_items(new_item, cells_count);
+    }
+
+    fn update_cell_item(&mut self, new_item: &PangoItemPosition) -> bool {
+        let cells_count = new_item.end_cell - new_item.start_cell + 1;
+        let items = &mut self.item_line[new_item.start_cell];
+        if items.len() == new_item.items.len() {
+            for (item, pango_item) in items.iter_mut().zip(&new_item.items) {
+                item.update((*pango_item).clone(), cells_count);
+            }
+        } else {
+            *items = Self::collect_items(new_item, cells_count);
+        }
+
+        self.line[new_item.start_cell].dirty = true;
+        true
+    }
+
+    fn collect_items(new_item: &PangoItemPosition, cells_count: usize) -> Box<[Item]> {
+        new_item
             .items
             .iter()
-            .map(|i| Item::new((*i).clone(), cells_count))
-            .collect();
+            .map(|item| Item::new((*item).clone(), cells_count))
+            .collect()
     }
 
     pub fn get_items(&self, cell_idx: usize) -> &[Item] {

--- a/src/ui_model/line.rs
+++ b/src/ui_model/line.rs
@@ -192,14 +192,7 @@ impl Line {
                 .iter()
                 .any(|c| c.dirty)
             {
-                self.item_line[new_item.start_cell] = new_item
-                    .items
-                    .iter()
-                    .map(|i| Item::new((*i).clone(), cell_count as usize))
-                    .collect();
-                self.line[new_item.start_cell].dirty = true;
-                self.mark_dirty(new_item.start_cell, new_item.start_cell);
-                true
+                self.update_cell_item(new_item)
             } else {
                 false
             }
@@ -256,14 +249,36 @@ impl Line {
             self.line[i].dirty = true;
             self.cell_to_item[i] = new_item.start_cell as i32;
         }
-        self.item_line[new_item.start_cell + 1..=new_item.end_cell].fill(Box::default());
+        if new_item.start_cell < new_item.end_cell {
+            self.item_line[new_item.start_cell + 1..=new_item.end_cell].fill(Box::default());
+        }
         let cells_count = new_item.end_cell - new_item.start_cell + 1;
-        self.item_line[new_item.start_cell] = new_item
+        self.item_line[new_item.start_cell] = Self::collect_items(new_item, cells_count);
+        self.mark_dirty(new_item.start_cell, new_item.end_cell);
+    }
+
+    fn update_cell_item(&mut self, new_item: &PangoItemPosition) -> bool {
+        let cells_count = new_item.end_cell - new_item.start_cell + 1;
+        let items = &mut self.item_line[new_item.start_cell];
+        if items.len() == new_item.items.len() {
+            for (item, pango_item) in items.iter_mut().zip(&new_item.items) {
+                item.update((*pango_item).clone(), cells_count);
+            }
+        } else {
+            *items = Self::collect_items(new_item, cells_count);
+        }
+
+        self.line[new_item.start_cell].dirty = true;
+        self.mark_dirty(new_item.start_cell, new_item.start_cell);
+        true
+    }
+
+    fn collect_items(new_item: &PangoItemPosition, cells_count: usize) -> Box<[Item]> {
+        new_item
             .items
             .iter()
-            .map(|i| Item::new((*i).clone(), cells_count))
-            .collect();
-        self.mark_dirty(new_item.start_cell, new_item.end_cell);
+            .map(|item| Item::new((*item).clone(), cells_count))
+            .collect()
     }
 
     fn include_double_width_cells(&self, mut range: DirtyRange) -> DirtyRange {
@@ -825,5 +840,26 @@ mod tests {
         line.mark_dirty(1, 1);
 
         assert_eq!(Some(0..2), line.expanded_dirty_range(),);
+    }
+
+    #[test]
+    fn test_update_cell_item_marks_dirty_range() {
+        let mut line = Line::new(4);
+        for cell in &mut line.line {
+            cell.dirty = false;
+        }
+        line.clear_dirty();
+
+        let item = PangoItemPosition {
+            items: Vec::new(),
+            start_cell: 1,
+            end_cell: 3,
+        };
+
+        assert!(line.update_cell_item(&item));
+        assert!(line.line[1].dirty);
+        assert!(!line.line[2].dirty);
+        assert!(!line.line[3].dirty);
+        assert_eq!(Some(1..2), line.dirty_range());
     }
 }


### PR DESCRIPTION
Line shaping still recreated small objects aggressively even when item boundaries stayed stable. In particular, merge() rebuilt Item wrappers for dirty spans, shape_dirty() allocated a fresh GlyphString per item, and snapshot_nvim() still walked every cell when a grouped item already covered multiple columns.

Reduce that churn in the text pipeline instead:
- update existing Item wrappers in place when the item layout is unchanged
- reuse each item's cached GlyphString buffer when reshaping text
- skip over grouped item spans during the text snapshot pass
- avoid recomputing the same foreground color for every item in a cell

This keeps the rendering path doing less allocation and less per-cell work while preserving the existing shaping behavior.