### PR TITLE
Resize the grid model in place

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -99,9 +99,7 @@ impl Grid {
     }
 
     pub fn resize(&mut self, columns: u64, rows: u64) {
-        if self.model.columns != columns as usize || self.model.rows != rows as usize {
-            self.model = UiModel::new(rows, columns);
-        }
+        self.model.resize(rows, columns);
     }
 
     pub fn cursor_goto(&mut self, row: usize, col: usize) {

--- a/src/ui_model/line.rs
+++ b/src/ui_model/line.rs
@@ -34,6 +34,34 @@ impl Line {
         }
     }
 
+    pub fn resize(&mut self, columns: usize) {
+        let old_len = self.line.len();
+        if old_len == columns {
+            return;
+        }
+
+        let mut line = std::mem::take(&mut self.line).into_vec();
+        let mut item_line = std::mem::take(&mut self.item_line).into_vec();
+        let mut cell_to_item = std::mem::take(&mut self.cell_to_item).into_vec();
+
+        // Preserve overlapping cell and shaping state; the next merge pass fixes any item clipped
+        // by a shrink because `dirty_line` is forced below.
+        if columns > old_len {
+            line.resize_with(columns, Cell::new_empty);
+            item_line.resize_with(columns, Box::default);
+            cell_to_item.resize(columns, -1);
+        } else {
+            line.truncate(columns);
+            item_line.truncate(columns);
+            cell_to_item.truncate(columns);
+        }
+
+        self.line = line.into_boxed_slice();
+        self.item_line = item_line.into_boxed_slice();
+        self.cell_to_item = cell_to_item.into_boxed_slice();
+        self.dirty_line = true;
+    }
+
     pub fn swap_with(&mut self, target: &mut Self, left: usize, right: usize) {
         // swap is faster then clone
         target.line[left..=right].swap_with_slice(&mut self.line[left..=right]);
@@ -246,6 +274,63 @@ impl<'a> PangoItemPositionIterator<'a> {
             iter: items.iter().peekable(),
             styled_line,
         }
+    }
+}
+
+#[cfg(test)]
+mod resize_tests {
+    use super::*;
+
+    #[test]
+    fn test_resize_preserves_prefix_state_and_only_initializes_new_cells() {
+        let mut line = Line::new(2);
+        line.line[0].ch.push('a');
+        line.line[0].dirty = false;
+        line.line[1].dirty = false;
+        line.cell_to_item[0] = 0;
+        line.dirty_line = false;
+
+        line.resize(4);
+
+        assert_eq!(4, line.line.len());
+        assert_eq!(4, line.item_line.len());
+        assert_eq!(4, line.cell_to_item.len());
+        assert_eq!("a", line.line[0].ch);
+        assert!(!line.line[0].dirty);
+        assert!(!line.line[1].dirty);
+        assert!(line.line[2].dirty);
+        assert!(line.line[3].dirty);
+        assert_eq!(0, line.cell_to_item[0]);
+        assert_eq!(-1, line.cell_to_item[2]);
+        assert_eq!(-1, line.cell_to_item[3]);
+        assert!(line.dirty_line);
+    }
+
+    #[test]
+    fn test_resize_shrinks_without_dirtying_remaining_prefix() {
+        let mut line = Line::new(4);
+        line.line[0].dirty = false;
+        line.line[1].dirty = true;
+        line.line[2].dirty = false;
+        line.line[3].dirty = false;
+        line.cell_to_item[0] = 0;
+        line.cell_to_item[1] = 0;
+        line.cell_to_item[2] = 2;
+        line.cell_to_item[3] = 3;
+        line.dirty_line = false;
+
+        line.resize(3);
+
+        assert_eq!(3, line.line.len());
+        assert_eq!(3, line.item_line.len());
+        assert_eq!(3, line.cell_to_item.len());
+        assert!(!line.line[0].dirty);
+        assert!(line.line[1].dirty);
+        assert!(!line.line[2].dirty);
+        assert_eq!(0, line.cell_to_item[0]);
+        assert_eq!(0, line.cell_to_item[1]);
+        assert_eq!(2, line.cell_to_item[2]);
+        assert!(line.dirty_line);
     }
 }
 

--- a/src/ui_model/mod.rs
+++ b/src/ui_model/mod.rs
@@ -40,6 +40,27 @@ impl UiModel {
         }
     }
 
+    pub fn resize(&mut self, rows: u64, columns: u64) {
+        let rows = rows as usize;
+        let columns = columns as usize;
+        if self.rows == rows && self.columns == columns {
+            return;
+        }
+
+        let mut model = std::mem::take(&mut self.model).into_vec();
+        model.truncate(rows);
+        for line in &mut model {
+            line.resize(columns);
+        }
+        model.resize_with(rows, || Line::new(columns));
+
+        self.rows = rows;
+        self.columns = columns;
+        self.cur_pos = Self::clamp_pos(self.cur_pos, rows, columns);
+        self.flushed_pos = Self::clamp_pos(self.flushed_pos, rows, columns);
+        self.model = model.into_boxed_slice();
+    }
+
     #[inline]
     pub fn model(&self) -> &[Line] {
         &self.model
@@ -205,6 +226,14 @@ impl UiModel {
             row.clear_glyphs();
         }
     }
+
+    #[inline]
+    fn clamp_pos((row, col): (usize, usize), rows: usize, columns: usize) -> (usize, usize) {
+        (
+            row.min(rows.saturating_sub(1)),
+            col.min(columns.saturating_sub(1)),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -216,5 +245,72 @@ mod tests {
         let mut model = UiModel::new(10, 20);
 
         model.scroll(1, 5, 1, 5, 3, &Rc::new(Highlight::new()));
+    }
+
+    #[test]
+    fn test_resize_preserves_existing_cells() {
+        let hl = Rc::new(Highlight::new());
+        let mut model = UiModel::new(2, 2);
+
+        model.put_one(0, 0, "a", false, hl.clone());
+        model.put_one(1, 1, "b", false, hl);
+        model.set_cursor(1, 1);
+        model.flush_cursor();
+
+        model.resize(3, 4);
+
+        assert_eq!(3, model.rows);
+        assert_eq!(4, model.columns);
+        assert_eq!("a", model.model[0].line[0].ch);
+        assert_eq!("b", model.model[1].line[1].ch);
+        assert_eq!("", model.model[2].line[0].ch);
+        assert_eq!((1, 1), model.get_real_cursor());
+        assert_eq!((1, 1), model.get_flushed_cursor());
+    }
+
+    #[test]
+    fn test_resize_clamps_cursor_and_truncates_cells() {
+        let hl = Rc::new(Highlight::new());
+        let mut model = UiModel::new(3, 3);
+
+        model.put_one(0, 0, "a", false, hl.clone());
+        model.put_one(2, 2, "z", false, hl);
+        model.set_cursor(2, 2);
+        model.flush_cursor();
+
+        model.resize(1, 1);
+
+        assert_eq!(1, model.rows);
+        assert_eq!(1, model.columns);
+        assert_eq!("a", model.model[0].line[0].ch);
+        assert_eq!((0, 0), model.get_real_cursor());
+        assert_eq!((0, 0), model.get_flushed_cursor());
+    }
+
+    #[test]
+    fn test_resize_noop_preserves_model_state() {
+        let hl = Rc::new(Highlight::new());
+        let mut model = UiModel::new(2, 2);
+
+        model.put_one(1, 1, "x", false, hl);
+        model.set_cursor(1, 1);
+        model.flush_cursor();
+        model.model[0].line[0].dirty = false;
+        model.model[0].dirty_line = false;
+
+        let model_ptr = model.model.as_ptr();
+        let line_ptr = model.model[0].line.as_ptr();
+
+        model.resize(2, 2);
+
+        assert_eq!(model_ptr, model.model.as_ptr());
+        assert_eq!(line_ptr, model.model[0].line.as_ptr());
+        assert_eq!(2, model.rows);
+        assert_eq!(2, model.columns);
+        assert_eq!("x", model.model[1].line[1].ch);
+        assert!(!model.model[0].line[0].dirty);
+        assert!(!model.model[0].dirty_line);
+        assert_eq!((1, 1), model.get_real_cursor());
+        assert_eq!((1, 1), model.get_flushed_cursor());
     }
 }


### PR DESCRIPTION
Grid resize still rebuilt the entire UiModel from scratch whenever rows or columns changed. That discarded existing line buffers, reset cursor state, and turned smooth resizing into unnecessary allocation and copy work.

Resize the model incrementally instead:
- reuse existing Line allocations for the overlapping grid area
- grow or shrink line storage in place when the column count changes
- add or remove only the rows that actually changed
- clamp cursor positions after shrinking instead of resetting the whole model
- cover the behavior with tests for growing and shrinking resizes

This keeps resize behavior the same at the UI level while avoiding full model reconstruction on every grid size change.