### PR TITLE
Move UI-originated Neovim RPCs off the GTK thread

### DIFF
--- a/src/cmd_line/mod.rs
+++ b/src/cmd_line/mod.rs
@@ -14,6 +14,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::cursor;
 use crate::highlight::HighlightMap;
+use crate::input;
 use crate::mode;
 use crate::nvim::{self, *};
 use crate::nvim_viewport::NvimViewport;
@@ -629,7 +630,7 @@ pub fn tree_button_press(
                 .collect()
         };
 
-        nvim.block_timeout(nvim.input(&apply_command)).report_err();
+        input::queue_input(nvim, apply_command);
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -76,16 +76,46 @@ pub fn convert_key(keyval: gdk::Key, modifiers: gdk::ModifierType) -> Option<Str
         .map(|ch| keyval_to_input_string(&ch.to_string(), modifiers))
 }
 
-pub fn im_input(nvim: &NvimSession, input: &str) {
+pub fn queue_input(nvim: &NvimSession, input: impl Into<String>) {
+    let input = input.into();
     debug!("nvim_input -> {input}");
 
+    let session = nvim.clone();
+    nvim.spawn_ui_serialized(async move {
+        session
+            .timeout(session.input(&input))
+            .await
+            .ok_and_report()
+            .expect("Failed to send input command to nvim");
+    });
+}
+
+pub fn queue_mouse_input(
+    nvim: &NvimSession,
+    button: &'static str,
+    action: &'static str,
+    modifiers: gdk::ModifierType,
+    row: i64,
+    col: i64,
+) {
+    let modifiers = keyval_to_input_string("", modifiers);
+    let session = nvim.clone();
+
+    nvim.spawn_ui_serialized(async move {
+        session
+            .timeout(session.input_mouse(button, action, &modifiers, 0, row, col))
+            .await
+            .ok_and_report()
+            .expect("Can't send mouse input event");
+    });
+}
+
+pub fn im_input(nvim: &NvimSession, input: &str) {
     let input: String = input
         .chars()
         .map(|ch| keyval_to_input_string(&ch.to_string(), gdk::ModifierType::empty()))
         .collect();
-    nvim.block_timeout(nvim.input(&input))
-        .ok_and_report()
-        .expect("Failed to send input command to nvim");
+    queue_input(nvim, input);
 }
 
 pub fn gtk_key_press(
@@ -94,10 +124,7 @@ pub fn gtk_key_press(
     modifiers: gdk::ModifierType,
 ) -> glib::Propagation {
     if let Some(input) = convert_key(keyval, modifiers) {
-        debug!("nvim_input -> {input}");
-        nvim.block_timeout(nvim.input(&input))
-            .ok_and_report()
-            .expect("Failed to send input command to nvim");
+        queue_input(nvim, input);
         glib::Propagation::Stop
     } else {
         glib::Propagation::Proceed

--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -12,6 +12,7 @@ use super::shell::ResizeState;
 
 use std::net::SocketAddr;
 use std::{
+    collections::VecDeque,
     convert::TryFrom,
     env, error, fmt,
     future::Future,
@@ -29,7 +30,7 @@ use tokio::{
     process::{ChildStdin, Command},
     runtime::{Builder as RuntimeBuilder, Runtime},
     sync::oneshot,
-    task::JoinHandle,
+    task::{JoinError, JoinHandle},
     time::{error::Elapsed, timeout},
 };
 use tokio_util::compat::*;
@@ -262,34 +263,98 @@ impl AsyncWrite for NvimWriter {
 pub type Neovim = nvim_rs::Neovim<Compat<NvimWriter>>;
 pub type Tabpage = nvim_rs::Tabpage<Compat<NvimWriter>>;
 
+type UiRequestFuture = BoxFuture<'static, ()>;
+
+struct QueuedUiRequest {
+    future: UiRequestFuture,
+    done_tx: oneshot::Sender<Result<(), JoinError>>,
+}
+
+#[derive(Default)]
+struct PendingUiRequests {
+    running: bool,
+    queue: VecDeque<QueuedUiRequest>,
+}
+
+impl PendingUiRequests {
+    fn enqueue(&mut self, request: QueuedUiRequest) -> bool {
+        self.queue.push_back(request);
+        if self.running {
+            false
+        } else {
+            self.running = true;
+            true
+        }
+    }
+
+    fn take_next(&mut self) -> Option<QueuedUiRequest> {
+        if let Some(request) = self.queue.pop_front() {
+            Some(request)
+        } else {
+            self.running = false;
+            None
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 struct UiRequestSerial {
-    tail: Arc<StdMutex<Option<oneshot::Receiver<()>>>>,
+    pending: Arc<StdMutex<PendingUiRequests>>,
 }
 
 impl UiRequestSerial {
     fn spawn(
         &self,
-        runtime: &Runtime,
+        runtime: &Arc<Runtime>,
         f: impl Future<Output = ()> + Send + 'static,
     ) -> JoinHandle<()> {
         let (done_tx, done_rx) = oneshot::channel();
-        let previous = {
-            let mut tail = self
-                .tail
+        let should_schedule = {
+            let mut pending = self
+                .pending
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            tail.replace(done_rx)
+            pending.enqueue(QueuedUiRequest {
+                future: f.boxed(),
+                done_tx,
+            })
         };
 
-        runtime.spawn(async move {
-            if let Some(previous) = previous {
-                let _ = previous.await;
-            }
+        if should_schedule {
+            let pending = self.pending.clone();
+            let drain_runtime = runtime.clone();
 
-            f.await;
-            let _ = done_tx.send(());
+            runtime.spawn(async move {
+                drain_ui_requests(pending, drain_runtime).await;
+            });
+        }
+
+        runtime.spawn(async move {
+            match done_rx.await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
+                Ok(Err(err)) => panic!("UI serialized task failed: {err}"),
+                Err(_) => panic!("UI serialized task queue dropped before completing request"),
+            }
         })
+    }
+}
+
+async fn drain_ui_requests(pending: Arc<StdMutex<PendingUiRequests>>, runtime: Arc<Runtime>) {
+    loop {
+        let request = {
+            let mut pending = pending
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            pending.take_next()
+        };
+
+        let Some(request) = request else {
+            return;
+        };
+
+        let result = runtime.spawn(request.future).await;
+        let _ = request.done_tx.send(result);
     }
 }
 
@@ -300,8 +365,8 @@ pub struct NvimSession {
     nvim: Neovim,
     timeout: Duration,
     runtime: Arc<Runtime>,
-    // UI-originated RPCs must keep their GTK submission order. We chain each task to the previous
-    // one before Tokio can schedule it, so runtime interleaving cannot reorder them.
+    // UI-originated RPCs must keep their GTK submission order, so we queue them and drain that
+    // FIFO one request at a time independent of Tokio's worker scheduling.
     ui_serial: UiRequestSerial,
 }
 
@@ -530,11 +595,13 @@ mod tests {
 
     #[test]
     fn ui_serialized_tasks_keep_submission_order() {
-        let runtime = RuntimeBuilder::new_multi_thread()
-            .worker_threads(2)
-            .enable_time()
-            .build()
-            .unwrap();
+        let runtime = Arc::new(
+            RuntimeBuilder::new_multi_thread()
+                .worker_threads(2)
+                .enable_time()
+                .build()
+                .unwrap(),
+        );
         let serial = UiRequestSerial::default();
         let order = Arc::new(StdMutex::new(Vec::new()));
 

--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -28,6 +28,7 @@ use tokio::{
     io::{self, AsyncWrite},
     process::{ChildStdin, Command},
     runtime::{Builder as RuntimeBuilder, Runtime},
+    sync::Mutex,
     task::JoinHandle,
     time::{error::Elapsed, timeout},
 };
@@ -268,6 +269,9 @@ pub struct NvimSession {
     nvim: Neovim,
     timeout: Duration,
     runtime: Arc<Runtime>,
+    // This mutex is a FIFO permit for UI-originated RPCs. Holding the guard is intentional so
+    // requests keep their submission order after leaving the GTK thread; it does not protect data.
+    ui_serial: Arc<Mutex<()>>,
 }
 
 type IoFuture<'a> = BoxFuture<'a, Result<(), Box<LoopError>>>;
@@ -300,6 +304,7 @@ impl NvimSession {
                 nvim,
                 timeout,
                 runtime,
+                ui_serial: Arc::new(Mutex::new(())),
             },
             io_future.boxed(),
         ))
@@ -330,6 +335,7 @@ impl NvimSession {
                 nvim,
                 timeout,
                 runtime,
+                ui_serial: Arc::new(Mutex::new(())),
             },
             io_future.boxed(),
         ))
@@ -362,6 +368,7 @@ impl NvimSession {
                 nvim,
                 timeout,
                 runtime,
+                ui_serial: Arc::new(Mutex::new(())),
             },
             io_future.boxed(),
         ))
@@ -391,6 +398,21 @@ impl NvimSession {
     #[inline]
     pub fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) -> JoinHandle<()> {
         self.runtime.spawn(f)
+    }
+
+    /// Spawn a task on this session's tokio runtime after waiting for earlier UI-originated
+    /// requests to finish.
+    #[doc(hidden)]
+    pub fn spawn_ui_serialized(
+        &self,
+        f: impl Future<Output = ()> + Send + 'static,
+    ) -> JoinHandle<()> {
+        let ui_serial = self.ui_serial.clone();
+
+        self.spawn(async move {
+            let _guard = ui_serial.lock().await;
+            f.await;
+        })
     }
 
     /// Wrap a future from an RPC call to neovim inside a timeout, and execute it on the current

--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -19,7 +19,7 @@ use std::{
     pin::Pin,
     process::Stdio,
     result,
-    sync::Arc,
+    sync::{Arc, Mutex as StdMutex},
     task::{Context, Poll},
     time::Duration,
 };
@@ -28,7 +28,7 @@ use tokio::{
     io::{self, AsyncWrite},
     process::{ChildStdin, Command},
     runtime::{Builder as RuntimeBuilder, Runtime},
-    sync::Mutex,
+    sync::oneshot,
     task::JoinHandle,
     time::{error::Elapsed, timeout},
 };
@@ -262,6 +262,37 @@ impl AsyncWrite for NvimWriter {
 pub type Neovim = nvim_rs::Neovim<Compat<NvimWriter>>;
 pub type Tabpage = nvim_rs::Tabpage<Compat<NvimWriter>>;
 
+#[derive(Clone, Default)]
+struct UiRequestSerial {
+    tail: Arc<StdMutex<Option<oneshot::Receiver<()>>>>,
+}
+
+impl UiRequestSerial {
+    fn spawn(
+        &self,
+        runtime: &Runtime,
+        f: impl Future<Output = ()> + Send + 'static,
+    ) -> JoinHandle<()> {
+        let (done_tx, done_rx) = oneshot::channel();
+        let previous = {
+            let mut tail = self
+                .tail
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            tail.replace(done_rx)
+        };
+
+        runtime.spawn(async move {
+            if let Some(previous) = previous {
+                let _ = previous.await;
+            }
+
+            f.await;
+            let _ = done_tx.send(());
+        })
+    }
+}
+
 /// Our main wrapper for `Neovim`, which also provides access to the timeout duration for this
 /// session
 #[derive(Clone)]
@@ -269,9 +300,9 @@ pub struct NvimSession {
     nvim: Neovim,
     timeout: Duration,
     runtime: Arc<Runtime>,
-    // This mutex is a FIFO permit for UI-originated RPCs. Holding the guard is intentional so
-    // requests keep their submission order after leaving the GTK thread; it does not protect data.
-    ui_serial: Arc<Mutex<()>>,
+    // UI-originated RPCs must keep their GTK submission order. We chain each task to the previous
+    // one before Tokio can schedule it, so runtime interleaving cannot reorder them.
+    ui_serial: UiRequestSerial,
 }
 
 type IoFuture<'a> = BoxFuture<'a, Result<(), Box<LoopError>>>;
@@ -304,7 +335,7 @@ impl NvimSession {
                 nvim,
                 timeout,
                 runtime,
-                ui_serial: Arc::new(Mutex::new(())),
+                ui_serial: UiRequestSerial::default(),
             },
             io_future.boxed(),
         ))
@@ -335,7 +366,7 @@ impl NvimSession {
                 nvim,
                 timeout,
                 runtime,
-                ui_serial: Arc::new(Mutex::new(())),
+                ui_serial: UiRequestSerial::default(),
             },
             io_future.boxed(),
         ))
@@ -368,7 +399,7 @@ impl NvimSession {
                 nvim,
                 timeout,
                 runtime,
-                ui_serial: Arc::new(Mutex::new(())),
+                ui_serial: UiRequestSerial::default(),
             },
             io_future.boxed(),
         ))
@@ -407,12 +438,7 @@ impl NvimSession {
         &self,
         f: impl Future<Output = ()> + Send + 'static,
     ) -> JoinHandle<()> {
-        let ui_serial = self.ui_serial.clone();
-
-        self.spawn(async move {
-            let _guard = ui_serial.lock().await;
-            f.await;
-        })
+        self.ui_serial.spawn(&self.runtime, f)
     }
 
     /// Wrap a future from an RPC call to neovim inside a timeout, and execute it on the current
@@ -495,6 +521,51 @@ impl Deref for NvimSession {
 impl DerefMut for NvimSession {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.nvim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ui_serialized_tasks_keep_submission_order() {
+        let runtime = RuntimeBuilder::new_multi_thread()
+            .worker_threads(2)
+            .enable_time()
+            .build()
+            .unwrap();
+        let serial = UiRequestSerial::default();
+        let order = Arc::new(StdMutex::new(Vec::new()));
+
+        let first_order = order.clone();
+        let first = serial.spawn(&runtime, async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            first_order
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(1);
+        });
+
+        let second_order = order.clone();
+        let second = serial.spawn(&runtime, async move {
+            second_order
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(2);
+        });
+
+        runtime.block_on(async {
+            first.await.unwrap();
+            second.await.unwrap();
+        });
+
+        assert_eq!(
+            *order
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![1, 2]
+        );
     }
 }
 

--- a/src/nvim/mod.rs
+++ b/src/nvim/mod.rs
@@ -30,7 +30,7 @@ use tokio::{
     process::{ChildStdin, Command},
     runtime::{Builder as RuntimeBuilder, Runtime},
     sync::oneshot,
-    task::{JoinError, JoinHandle},
+    task::JoinHandle,
     time::{error::Elapsed, timeout},
 };
 use tokio_util::compat::*;
@@ -267,7 +267,7 @@ type UiRequestFuture = BoxFuture<'static, ()>;
 
 struct QueuedUiRequest {
     future: UiRequestFuture,
-    done_tx: oneshot::Sender<Result<(), JoinError>>,
+    done_tx: oneshot::Sender<()>,
 }
 
 #[derive(Default)]
@@ -322,25 +322,21 @@ impl UiRequestSerial {
 
         if should_schedule {
             let pending = self.pending.clone();
-            let drain_runtime = runtime.clone();
-
             runtime.spawn(async move {
-                drain_ui_requests(pending, drain_runtime).await;
+                drain_ui_requests(pending).await;
             });
         }
 
         runtime.spawn(async move {
             match done_rx.await {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
-                Ok(Err(err)) => panic!("UI serialized task failed: {err}"),
+                Ok(()) => {}
                 Err(_) => panic!("UI serialized task queue dropped before completing request"),
             }
         })
     }
 }
 
-async fn drain_ui_requests(pending: Arc<StdMutex<PendingUiRequests>>, runtime: Arc<Runtime>) {
+async fn drain_ui_requests(pending: Arc<StdMutex<PendingUiRequests>>) {
     loop {
         let request = {
             let mut pending = pending
@@ -353,7 +349,7 @@ async fn drain_ui_requests(pending: Arc<StdMutex<PendingUiRequests>>, runtime: A
             return;
         };
 
-        let result = runtime.spawn(request.future).await;
+        let result = request.future.await;
         let _ = request.done_tx.send(result);
     }
 }

--- a/src/popup_menu/mod.rs
+++ b/src/popup_menu/mod.rs
@@ -16,6 +16,7 @@ use gtk::prelude::*;
 
 use crate::{
     highlight::HighlightMap,
+    input,
     nvim::{self, ErrorReport, NeovimClient, PendingPopupMenu, PopupMenuItem},
     render::{self, CellMetrics},
     shell::RenderState,
@@ -604,7 +605,7 @@ pub fn list_select(state: &mut State, idx: u32, last_command: &str) {
                 .collect()
         };
 
-        nvim.block_timeout(nvim.input(&apply_command)).report_err();
+        input::queue_input(&nvim, apply_command);
     }
     state.prev_selected = Some(idx);
 }

--- a/src/popup_menu/mod.rs
+++ b/src/popup_menu/mod.rs
@@ -16,6 +16,7 @@ use gtk::prelude::*;
 
 use crate::{
     highlight::HighlightMap,
+    input,
     nvim::{self, ErrorReport, NeovimClient, PendingPopupMenu, PopupMenuItem},
     render::{self, CellMetrics},
     shell::RenderState,
@@ -556,7 +557,7 @@ pub fn list_select(state: &mut State, idx: u32, last_command: &str) {
                 .collect()
         };
 
-        nvim.block_timeout(nvim.input(&apply_command)).report_err();
+        input::queue_input(&nvim, apply_command);
     }
     state.prev_selected = Some(idx);
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -37,7 +37,6 @@ use crate::Args;
 use crate::cmd_line::{CmdLine, CmdLineContext};
 use crate::cursor::{Cursor, CursorRedrawCb};
 use crate::input;
-use crate::input::keyval_to_input_string;
 use crate::mode;
 use crate::nvim_viewport::NvimViewport;
 use crate::popup_menu::PopupMenu;
@@ -480,7 +479,7 @@ impl State {
         if self.popup_menu.is_open()
             && let Some(nvim) = self.nvim()
         {
-            nvim.block_timeout(nvim.input("<Esc>")).report_err();
+            input::queue_input(&nvim, "<Esc>");
         }
     }
 
@@ -1440,16 +1439,7 @@ fn mouse_input(
 ) {
     if let Some(nvim) = shell.nvim() {
         let (col, row) = mouse_coordinates_to_nvim(shell, position);
-        let input_string = keyval_to_input_string("", state);
-
-        let nvim_clone = nvim.clone();
-        nvim.spawn(async move {
-            nvim_clone
-                .input_mouse(button, action, &input_string, 0, row as i64, col as i64)
-                .await
-                .ok_and_report()
-                .expect("Can't send mouse input event");
-        });
+        input::queue_mouse_input(&nvim, button, action, state, row as i64, col as i64);
     }
 }
 

--- a/src/tabline.rs
+++ b/src/tabline.rs
@@ -34,11 +34,16 @@ impl State {
     }
 
     fn switch_page(&self, idx: u32) {
-        let target = &self.tabpages[idx as usize];
-        if Some(target) != self.selected.as_ref() {
+        let target = self.tabpages[idx as usize].clone();
+        if Some(&target) != self.selected.as_ref() {
             let nvim = self.nvim();
-            nvim.block_timeout(nvim.set_current_tabpage(target))
-                .report_err();
+            let session = nvim.clone();
+            nvim.spawn_ui_serialized(async move {
+                session
+                    .timeout(session.set_current_tabpage(&target))
+                    .await
+                    .report_err();
+            });
         }
     }
 


### PR DESCRIPTION
Several UI interactions still called block_timeout(...) directly from GTK event handlers. That made keyboard input, IME commit, popup selection, wildmenu selection, and tab switching wait synchronously for Neovim and could turn routine interaction into visible stutter under load.

Move those requests to an asynchronous path instead, using a serialized UI RPC queue to preserve request ordering after leaving the GTK thread. Also route mouse input through the same queue so popup-closing <Esc> cannot race with subsequent mouse or scroll RPCs.

While doing that, make the serialization helper more explicit, document the Mutex<()> as an ordering permit rather than data protection, remove the redundant clone in the input path, and keep the explicit failure policy for input dispatch.